### PR TITLE
Adds startup delay to preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ is a Gnome Shell extension which keeps track of all application windows and rest
   </a>
 </p>
 
-## screenshots
+## Screenshots
 
 #### QuickSettings
 
@@ -31,43 +31,43 @@ The toggle in quicksettings is connected to the "Freeze saves" switch of setting
 
 ![screenshot: overrides preferences](docs/screenshot-overrides.png)
 
-## getting started
+## Getting started
 
-most settings can be modified via the extension preferences dialog.
+Most settings can be modified via the extension preferences dialog.
 
-### defaults
+### Defaults
 
-the first step is to choose your **Default Synchronization Mode**: `IGNORE` or `RESTORE`. `IGNORE` will keep track of windows but will not restore any unless an **Override** with `RESTORE` behavior is created. `RESTORE` will keep track and restore all windows unless an **Override** with `IGNORE` behavior is created.
+The first step is to choose your **Default Synchronization Mode**: `IGNORE` or `RESTORE`. `IGNORE` will keep track of windows but will not restore any unless an **Override** with `RESTORE` behavior is created. `RESTORE` will keep track and restore all windows unless an **Override** with `IGNORE` behavior is created.
 
-next is to choose your global **Match Threshold**, the default works well for most use cases. a number closer to `0.0` will match windows with less similar attributes, whereas `1.0` requires an exact match.
+Next is to choose your global **Match Threshold**, the default works well for most use cases. a number closer to `0.0` will match windows with less similar attributes, whereas `1.0` requires an exact match.
 
-advanced users can also tune extension resource usage. adjust **Sync Frequency** (memory and CPU) and **Save Frequency** (disk I/O).
+Advanced users can also tune extension resource usage. adjust **Sync Frequency** (memory and CPU) and **Save Frequency** (disk I/O).
 
-after you've dialed in your overrides, the learning apparatus can be paused. enable **Freeze Saves** to prevent changes to Saved Windows. N.B. this lose track of windows if their titles change.
+After you've dialed in your overrides, the learning apparatus can be paused. enable **Freeze Saves** to prevent changes to Saved Windows. N.B. this lose track of windows if their titles change.
 
 ### overrides
 
-to create an override, visit the **Saved Windows** tab.
+To create an override, visit the **Saved Windows** tab.
 
-to create an override for a specific window, click **OVERRIDE**.
+To create an override for a specific window, click **OVERRIDE**.
 
-to create an override for an entire application, click **OVERRIDE (ANY)**.
+To create an override for an entire application, click **OVERRIDE (ANY)**.
 
-after you've created an override, visit the **Overrides** tab.
+After you've created an override, visit the **Overrides** tab.
 
-you can change the IGNORE/RESTORE behavior here for apps and windows.
+You can change the IGNORE/RESTORE behavior here for apps and windows.
 
-for applications, a custom **Match Threshold** can be set.
+For applications, a custom **Match Threshold** can be set.
 
-## limitations
+## Limitations
 
-LIMITATION: terminals which include the current directory in the title may not reach the match threshold if they do not preserve the working directory across restarts. WORKAROUND: create a per-app override (see above) and set the threshold to a lower value, eg. `0.2`
+LIMITATION: Terminals which include the current directory in the title may not reach the match threshold if they do not preserve the working directory across restarts. WORKAROUND: create a per-app override (see above) and set the threshold to a lower value, eg. `0.2`
 
-LIMITATION: multi-monitor is not well supported and may result in windows becoming "stuck". WORKAROUND: visit the "Saved Windows" tab in preferences and delete any stuck windows.
+LIMITATION: Multi-monitor is not well supported and may result in windows becoming "stuck". WORKAROUND: visit the "Saved Windows" tab in preferences and delete any stuck windows.
 
-## troubleshooting
+## Troubleshooting
 
-if everything is horribly broken, clear your Saved Windows:
+If everything is horribly broken, clear your Saved Windows:
 
 ```
 $ gnome-extensions disable SmartAutoMoveNG@lauinger-clan.de
@@ -77,18 +77,18 @@ $ dconf write /org/gnome/shell/extensions/SmartAutoMoveNG/saved-windows '{}'
 $ gnome-extensions enable SmartAutoMoveNG@lauinger-clan.de
 ```
 
-## behavior
+## Behavior
 
-because there is no way to uniquely distinguish individual windows from an application across restarts, SmartAutoMoveNG
-uses a heuristic to uniquely identify them. this is primarily based on startup order and title. in cases where there are multiple windows with the same title, they are restored based on relative startup sequence.
+Because there is no way to uniquely distinguish individual windows from an application across restarts, SmartAutoMoveNG
+uses a heuristic to uniquely identify them. This is primarily based on startup order and title. In cases where there are multiple windows with the same title, they are restored based on relative startup sequence.
 
-titles are matched using Levenstein distance. the match bonus for title is calculated based on `(title length - distance) / title length`.
+Titles are matched using Levenstein distance. The match bonus for title is calculated based on `(title length - distance) / title length`.
 
-## settings
+## Settings
 
-most settings can be modified from the preferences GUI. this section documents all of the dconf values and is only recommended for advanced users.
+Most settings can be modified from the preferences GUI. This section documents all of the dconf values and is only recommended for advanced users.
 
-enable debug logging:
+Enable debug logging:
 
 ```
 $ dconf write /org/gnome/shell/extensions/SmartAutoMoveNG/debug-logging true
@@ -106,7 +106,7 @@ set the window synchronization (update/restore) frequency to 50ms:
 $ dconf write /org/gnome/shell/extensions/SmartAutoMoveNG/sync-frequency 50
 ```
 
-default to ignoring windows unless explicitly defined. restore all windows of the gnome-calculator app, all firefox windows except for the profile chooser, and Nautilus only if the window title is "Downloads":
+Default to ignoring windows unless explicitly defined. Restore all windows of the gnome-calculator app, all firefox windows except for the profile chooser, and Nautilus only if the window title is "Downloads":
 /
 
 ```
@@ -114,32 +114,32 @@ $ dconf write /org/gnome/shell/extensions/SmartAutoMoveNG/sync-mode "'IGNORE'"
 $ dconf write /org/gnome/shell/extensions/SmartAutoMoveNG/overrides '{"gnome-calculator": [{"action":1}], "firefox": [{"query": {"title": "Firefox - Choose User Profile"}, "action": 0}, {"action": 1}],"org.gnome.Nautilus":[{"query":{"title":"Downloads"},"action":1}]}'
 ```
 
-default to restoring all windows, but ignore the firefox profile chooser and any nautilus windows:
+Default to restoring all windows, but ignore the firefox profile chooser and any nautilus windows:
 
 ```
 $ dconf write /org/gnome/shell/extensions/SmartAutoMoveNG/sync-mode "'RESTORE'"
 $ dconf write /org/gnome/shell/extensions/SmartAutoMoveNG/overrides '{"firefox": [{"query": {"title": "Firefox - Choose User Profile"}, "action": 0}], "org.gnome.Nautilus": [{"action":0}]}'
 ```
 
-show all saved firefox windows (N.B. `jq` will fail if window title contains `\`):
+Show all saved firefox windows (N.B. `jq` will fail if window title contains `\`):
 
 ```
 $ dconf read /org/gnome/shell/extensions/SmartAutoMoveNG/saved-windows | sed "s/^'//; s/'$//" | jq -C .Firefox | less -SR
 ```
 
-there are example configs in the `examples/` dir which can be loaded (N.B. while extension is disabled) with:
+There are example configs in the `examples/` dir which can be loaded (N.B. while extension is disabled) with:
 
 ```
 $ dconf load /org/gnome/shell/extensions/SmartAutoMoveNG/ < ./examples/default-restore.dconf
 ```
 
-you can backup your config (restore is the same as above):
+You can backup your config (restore is the same as above):
 
 ```
 $ dconf dump /org/gnome/shell/extensions/SmartAutoMoveNG/ > SmartAutoMoveNG.dconf
 ```
 
-the gsettings tool can also be used to manipulate these values:
+The gsettings tool can also be used to manipulate these values:
 
 ```
 $ gsettings --schemadir ./SmartAutoMoveNG@lauinger-clan.de/schemas/ set org.gnome.shell.extensions.SmartAutoMoveNG sync-mode 'RESTORE'

--- a/SmartAutoMoveNG@lauinger-clan.de/metadata.json
+++ b/SmartAutoMoveNG@lauinger-clan.de/metadata.json
@@ -10,6 +10,6 @@
     },
     "original-author": "khimaros",
     "gettext-domain": "SmartAutoMoveNG",
-    "version-name": "48.5",
+    "version-name": "48.6",
     "shell-version": ["47", "48"]
 }

--- a/SmartAutoMoveNG@lauinger-clan.de/prefs.js
+++ b/SmartAutoMoveNG@lauinger-clan.de/prefs.js
@@ -85,7 +85,7 @@ export default class SAMPreferences extends ExtensionPreferences {
         const page3 = builder.get_object("smartautomove_page3");
         window.add(page3);
         const matchthresholdspin = builder.get_object("match-threshold-spin");
-        matchthresholdspin.set_climb_rate(0.1);
+        matchthresholdspin.set_climb_rate(0.05);
         matchthresholdspin.set_digits(2);
         matchthresholdspin.set_numeric(true);
         const syncfrequencyspin = builder.get_object("sync-frequency-spin");
@@ -94,6 +94,9 @@ export default class SAMPreferences extends ExtensionPreferences {
         const savefrequencyspin = builder.get_object("save-frequency-spin");
         savefrequencyspin.set_climb_rate(50);
         savefrequencyspin.set_numeric(true);
+        const startupdelayspin = builder.get_object("startup-delay-spin");
+        startupdelayspin.set_climb_rate(100);
+        startupdelayspin.set_numeric(true);
         this._rebuildOverrides = true; // do we need to rebuild the overrides list?
 
         this._general(this.getSettings(), builder);
@@ -126,6 +129,7 @@ export default class SAMPreferences extends ExtensionPreferences {
                 "save-frequency-spin",
                 "value",
             ],
+            [Common.SETTINGS_KEY_STARTUP_DELAY, "startup-delay-spin", "value"],
             [Common.SETTINGS_KEY_FREEZE_SAVES, "freeze-saves-switch", "active"],
             [
                 Common.SETTINGS_KEY_ACTIVATE_WORKSPACE,

--- a/SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui
+++ b/SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui
@@ -39,8 +39,8 @@
                 <property name="lower">0</property>
                 <property name="upper">1</property>
                 <property name="value">0.7</property>
-                <property name="page-increment">0</property>
                 <property name="step-increment">0.05</property>
+                <property name="page-increment">0.1</property>
               </object>
             </property>
           </object>
@@ -72,6 +72,22 @@
                 <property name="upper">10000</property>
                 <property name="value">1000</property>
                 <property name="step-increment">50</property>
+                <property name="page-increment">1000</property>
+              </object>
+            </property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwSpinRow" id="startup-delay-spin">
+            <property name="title" translatable="yes">Startup Delay (ms)</property>
+            <property name="subtitle" translatable="yes">Period of time in milliseconds to wait between seeing a window and writing it to the in-memory store.</property>
+            <property name="tooltip-text" translatable="yes">Period of time in milliseconds to wait between seeing a window and writing it to the in-memory store.</property>
+            <property name="adjustment">
+              <object class="GtkAdjustment">
+                <property name="lower">500</property>
+                <property name="upper">10000</property>
+                <property name="value">2500</property>
+                <property name="step-increment">100</property>
                 <property name="page-increment">1000</property>
               </object>
             </property>


### PR DESCRIPTION
- Bumps the extension version to 48.6.
- Adds a setting to delay the start of the extension. This helps prevent issues that might arise if the extension starts before all dependencies are ready.