### PR TITLE
Updates to GNOME Shell 49

### DIFF
--- a/SmartAutoMoveNG@lauinger-clan.de/extension.js
+++ b/SmartAutoMoveNG@lauinger-clan.de/extension.js
@@ -283,7 +283,7 @@ export default class SmartAutoMoveNG extends Extension {
             //pid: win.get_pid(),
             //user_time: win.get_user_time(),
             workspace: win.get_workspace().index(),
-            maximized: win.get_maximized(),
+            maximized: win.is_maximized(),
             fullscreen: win.is_fullscreen(),
             above: win.is_above(),
             monitor: win.get_monitor(),

--- a/SmartAutoMoveNG@lauinger-clan.de/metadata.json
+++ b/SmartAutoMoveNG@lauinger-clan.de/metadata.json
@@ -10,6 +10,6 @@
     },
     "original-author": "khimaros",
     "gettext-domain": "SmartAutoMoveNG",
-    "version-name": "48.8",
-    "shell-version": ["48"]
+    "version-name": "49.0",
+    "shell-version": ["49"]
 }


### PR DESCRIPTION
Updates the extension to be compatible with GNOME Shell 49.

Replaces deprecated `win.get_maximized()` with `win.is_maximized()`.