### PR TITLE
Adds option to ignore monitor when moving windows

### DIFF
--- a/SmartAutoMoveNG@lauinger-clan.de/extension.js
+++ b/SmartAutoMoveNG@lauinger-clan.de/extension.js
@@ -125,6 +125,7 @@ export default class SmartAutoMoveNG extends Extension {
             [Common.SETTINGS_KEY_IGNORE_WORKSPACE, this._handleChangedIgnoreWorkspace.bind(this)],
             [Common.SETTINGS_KEY_OVERRIDES, this._handleChangedOverrides.bind(this)],
             [Common.SETTINGS_KEY_SAVED_WINDOWS, this._handleChangedSavedWindows.bind(this)],
+            [Common.SETTINGS_KEY_IGNORE_MONITOR, this._handleChangedIgnoreMonitor.bind(this)],
         ];
         for (const [key, handler] of signalMap) {
             const id = this._settings.connect("changed::" + key, handler);
@@ -238,6 +239,7 @@ export default class SmartAutoMoveNG extends Extension {
         this._handleChangedIgnoreWorkspace();
         this._handleChangedOverrides();
         this._handleChangedSavedWindows();
+        this._handleChangedIgnoreMonitor();
         this._dumpSavedWindows();
     }
 
@@ -369,7 +371,9 @@ export default class SmartAutoMoveNG extends Extension {
     }
 
     _moveWindow(win, sw) {
-        win.move_to_monitor(sw.monitor);
+        if (!this._ignoreMonitor) {
+            win.move_to_monitor(sw.monitor);
+        }
 
         let ws = global.workspaceManager.get_workspace_by_index(sw.workspace);
         if (!this._ignoreWorkspace) {
@@ -580,5 +584,10 @@ export default class SmartAutoMoveNG extends Extension {
         this._updateStats();
         this._indicator.menuToggle.setMenuTitleAndHeader(this._savedWindowsCount, this._overridesCount);
         this._debug("handleChangedSavedWindows(): " + JSON.stringify(this._savedWindows));
+    }
+
+    _handleChangedIgnoreMonitor() {
+        this._ignoreMonitor = this._settings.get_boolean(Common.SETTINGS_KEY_IGNORE_MONITOR);
+        this._debug("_handleChangedIgnoreMonitor(): " + this._ignoreMonitor);
     }
 }

--- a/SmartAutoMoveNG@lauinger-clan.de/lib/common.js
+++ b/SmartAutoMoveNG@lauinger-clan.de/lib/common.js
@@ -12,6 +12,7 @@ export const SETTINGS_KEY_FREEZE_SAVES = "freeze-saves";
 export const SETTINGS_KEY_ACTIVATE_WORKSPACE = "activate-workspace";
 export const SETTINGS_KEY_IGNORE_POSITION = "ignore-position";
 export const SETTINGS_KEY_IGNORE_WORKSPACE = "ignore-workspace";
+export const SETTINGS_KEY_IGNORE_MONITOR = "ignore-monitor";
 export const SETTINGS_KEY_OVERRIDES = "overrides";
 
 // sync mode enum values
@@ -29,6 +30,7 @@ export const DEFAULT_FREEZE_SAVES = false;
 export const DEFAULT_ACTIVATE_WORKSPACE = true;
 export const DEFAULT_IGNORE_POSITION = false;
 export const DEFAULT_IGNORE_WORKSPACE = false;
+export const DEFAULT_IGNORE_MONITOR = false;
 
 function levensteinDistance(a, b) {
     let m = [],
@@ -46,10 +48,7 @@ function levensteinDistance(a, b) {
             if (b.charAt(i - 1) === a.charAt(j - 1)) {
                 m[i][j] = m[i - 1][j - 1];
             } else {
-                m[i][j] = min(
-                    m[i - 1][j - 1] + 1,
-                    min(m[i][j - 1] + 1, m[i - 1][j] + 1)
-                );
+                m[i][j] = min(m[i - 1][j - 1] + 1, min(m[i][j - 1] + 1, m[i - 1][j] + 1));
             }
         }
     }
@@ -58,8 +57,7 @@ function levensteinDistance(a, b) {
 }
 
 export function scoreWindow(sw, query) {
-    if (query.occupied !== undefined && sw.occupied !== query.occupied)
-        return 0;
+    if (query.occupied !== undefined && sw.occupied !== query.occupied) return 0;
     let match_parts = 0;
     let query_parts = 0;
     Object.keys(query).forEach(function (key) {
@@ -90,9 +88,7 @@ export function findSavedWindow(saved_windows, wsh, query, threshold) {
         scores.set(swi, score);
     });
 
-    let sorted_scores = new Map(
-        [...scores.entries()].sort((a, b) => b[1] - a[1])
-    );
+    let sorted_scores = new Map([...scores.entries()].sort((a, b) => b[1] - a[1]));
 
     let best_swi = sorted_scores.keys().next().value;
     let best_score = sorted_scores.get(best_swi);
@@ -133,24 +129,13 @@ export function findOverride(overrides, wsh, sw, threshold) {
     return override;
 }
 
-export function matchedWindow(
-    saved_windows,
-    overrides,
-    wsh,
-    title,
-    default_match_threshold
-) {
+export function matchedWindow(saved_windows, overrides, wsh, title, default_match_threshold) {
     let o = findOverride(overrides, wsh, { title: title }, 1.0);
 
     let threshold = default_match_threshold;
     if (o !== undefined && o.threshold !== undefined) threshold = o.threshold;
 
-    let [swi] = findSavedWindow(
-        saved_windows,
-        wsh,
-        { title: title, occupied: false },
-        threshold
-    );
+    let [swi] = findSavedWindow(saved_windows, wsh, { title: title, occupied: false }, threshold);
 
     if (swi === undefined) return [undefined, undefined];
 
@@ -160,9 +145,7 @@ export function matchedWindow(
 }
 
 export function cleanupNonOccupiedWindows(settings) {
-    const saved_windows = JSON.parse(
-        settings.get_string(SETTINGS_KEY_SAVED_WINDOWS)
-    );
+    const saved_windows = JSON.parse(settings.get_string(SETTINGS_KEY_SAVED_WINDOWS));
 
     Object.keys(saved_windows).forEach((wsh) => {
         let sws = saved_windows[wsh];
@@ -172,8 +155,5 @@ export function cleanupNonOccupiedWindows(settings) {
         }
     });
 
-    settings.set_string(
-        SETTINGS_KEY_SAVED_WINDOWS,
-        JSON.stringify(saved_windows)
-    );
+    settings.set_string(SETTINGS_KEY_SAVED_WINDOWS, JSON.stringify(saved_windows));
 }

--- a/SmartAutoMoveNG@lauinger-clan.de/prefs.js
+++ b/SmartAutoMoveNG@lauinger-clan.de/prefs.js
@@ -113,6 +113,7 @@ export default class SAMPreferences extends ExtensionPreferences {
             [Common.SETTINGS_KEY_ACTIVATE_WORKSPACE, "activate-workspace-switch", "active"],
             [Common.SETTINGS_KEY_IGNORE_POSITION, "ignore-position-switch", "active"],
             [Common.SETTINGS_KEY_IGNORE_WORKSPACE, "ignore-workspace-switch", "active"],
+            [Common.SETTINGS_KEY_IGNORE_MONITOR, "ignore-monitor-switch", "active"],
         ];
 
         generalBindings.forEach(([key, widgetId, property]) => {
@@ -369,6 +370,7 @@ export default class SAMPreferences extends ExtensionPreferences {
                 Common.SETTINGS_KEY_ACTIVATE_WORKSPACE,
                 Common.SETTINGS_KEY_IGNORE_POSITION,
                 Common.SETTINGS_KEY_IGNORE_WORKSPACE,
+                Common.SETTINGS_KEY_IGNORE_MONITOR,
             ];
             keys.forEach((key) => {
                 if (settings.is_writable(key)) {

--- a/SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml
+++ b/SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml
@@ -64,5 +64,10 @@
       <summary>Ignore workspace</summary>
       <description>Do not restore windows' workspace.</description>
     </key>
+    <key name="ignore-monitor" type="b">
+      <default>false</default>
+      <summary>Ignore Monitor</summary>
+      <description>Do not restore windows' monitor.</description>
+    </key>
   </schema>
 </schemalist>

--- a/SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui
+++ b/SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui
@@ -121,6 +121,13 @@
             <property name="tooltip-text" translatable="yes">Do not restore windows&apos; workspace.</property>
           </object>
         </child>
+        <child>
+          <object class="AdwSwitchRow" id="ignore-monitor-switch">
+            <property name="title" translatable="yes">Ignore Monitor</property>
+            <property name="subtitle" translatable="yes">Do not restore windows&apos; monitor.</property>
+            <property name="tooltip-text" translatable="yes">Do not restore windows&apos; monitor.</property>
+          </object>
+        </child>
       </object>
     </child>
   </object>

--- a/po/SmartAutoMoveNG.pot
+++ b/po/SmartAutoMoveNG.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-25 18:46+0200\n"
+"POT-Creation-Date: 2025-07-26 08:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,12 +20,12 @@ msgstr ""
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:42
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:59
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:9
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:129
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:136
 msgid "Saved Windows"
 msgstr ""
 
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:44
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:136
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:143
 msgid "Cleanup Non-occupied Windows"
 msgstr ""
 
@@ -36,7 +36,7 @@ msgstr ""
 
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:59
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:44
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:144
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:151
 msgid "Overrides"
 msgstr ""
 
@@ -48,51 +48,51 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:173
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:174
 msgid "Select app"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:232
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:335
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:233
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:336
 msgid "ANY"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:256
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:257
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:25
 msgid "IGNORE"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:257
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:258
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:26
 msgid "RESTORE"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:258
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:259
 msgid "DEFAULT"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:275
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:314
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:276
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:315
 msgid "Delete"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:309
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:310
 msgid "Not occupied"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:326
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:327
 msgid "OVERRIDE"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:339
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:340
 msgid "OVERRIDE (ANY)"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:395
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:397
 msgid "Reset Settings"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:401
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:403
 msgid "Reset all settings to default values"
 msgstr ""
 
@@ -212,6 +212,17 @@ msgstr ""
 msgid "Do not restore windows' workspace."
 msgstr ""
 
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:69
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:126
+msgid "Ignore Monitor"
+msgstr ""
+
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:70
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:127
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:128
+msgid "Do not restore windows' monitor."
+msgstr ""
+
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:5
 msgid "General"
 msgstr ""
@@ -240,6 +251,6 @@ msgstr ""
 msgid "Ignore Workspace"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:151
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:158
 msgid "Add Application"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-25 18:46+0200\n"
-"PO-Revision-Date: 2025-06-25 18:47+0200\n"
+"POT-Creation-Date: 2025-07-26 08:47+0200\n"
+"PO-Revision-Date: 2025-07-26 08:51+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
 "Language: de\n"
@@ -21,12 +21,12 @@ msgstr ""
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:42
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:59
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:9
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:129
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:136
 msgid "Saved Windows"
 msgstr "Gespeicherte Fenster"
 
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:44
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:136
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:143
 msgid "Cleanup Non-occupied Windows"
 msgstr "Nicht besetzte Fenster aufräumen"
 
@@ -37,7 +37,7 @@ msgstr "Einstellungen"
 
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:59
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:44
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:144
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:151
 msgid "Overrides"
 msgstr "Überschreibungen"
 
@@ -49,51 +49,51 @@ msgstr "Auswählen"
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:173
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:174
 msgid "Select app"
 msgstr "App auswählen"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:232
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:335
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:233
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:336
 msgid "ANY"
 msgstr "Beliebig"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:256
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:257
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:25
 msgid "IGNORE"
 msgstr "Ignorieren"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:257
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:258
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:26
 msgid "RESTORE"
 msgstr "Wiederherstellen"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:258
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:259
 msgid "DEFAULT"
 msgstr "Standard"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:275
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:314
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:276
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:315
 msgid "Delete"
 msgstr "Löschen"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:309
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:310
 msgid "Not occupied"
 msgstr "Nicht besetzt"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:326
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:327
 msgid "OVERRIDE"
 msgstr "Überschreiben"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:339
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:340
 msgid "OVERRIDE (ANY)"
 msgstr "Überschreiben (beliebig)"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:395
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:397
 msgid "Reset Settings"
 msgstr "Einstellungen zurücksetzen"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:401
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:403
 msgid "Reset all settings to default values"
 msgstr "Alle Einstellungen auf Standardwerte zurücksetzen"
 
@@ -220,6 +220,17 @@ msgstr "Arbeitsbereich ignorieren"
 msgid "Do not restore windows' workspace."
 msgstr "Arbeitsbereich der Fenster nicht wiederherstellen."
 
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:69
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:126
+msgid "Ignore Monitor"
+msgstr "Monitor ignorieren"
+
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:70
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:127
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:128
+msgid "Do not restore windows' monitor."
+msgstr "Monitor der Fenster nicht wiederherstellen."
+
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:5
 msgid "General"
 msgstr "Allgemein"
@@ -248,7 +259,7 @@ msgstr "Position ignorieren"
 msgid "Ignore Workspace"
 msgstr "Arbeitsbereich ignorieren"
 
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:151
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:158
 msgid "Add Application"
 msgstr "Anwendung hinzufügen"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-25 18:46+0200\n"
-"PO-Revision-Date: 2025-06-25 18:48+0200\n"
+"POT-Creation-Date: 2025-07-26 08:47+0200\n"
+"PO-Revision-Date: 2025-07-26 08:52+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: RU <LL@li.org>\n"
 "Language: ru\n"
@@ -21,12 +21,12 @@ msgstr ""
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:42
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:59
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:9
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:129
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:136
 msgid "Saved Windows"
 msgstr "Сохраненные окна"
 
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:44
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:136
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:143
 msgid "Cleanup Non-occupied Windows"
 msgstr "Очистка незанятых окон"
 
@@ -37,7 +37,7 @@ msgstr "Настройки"
 
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:59
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:44
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:144
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:151
 msgid "Overrides"
 msgstr "Переопределить"
 
@@ -49,51 +49,51 @@ msgstr "Выбрать"
 msgid "Cancel"
 msgstr "Отмена"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:173
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:174
 msgid "Select app"
 msgstr "Приложение"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:232
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:335
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:233
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:336
 msgid "ANY"
 msgstr "ЛЮБОЙ"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:256
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:257
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:25
 msgid "IGNORE"
 msgstr "ИГНОРИРОВАТЬ"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:257
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:258
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:26
 msgid "RESTORE"
 msgstr "ВОССТАНОВИТЬ"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:258
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:259
 msgid "DEFAULT"
 msgstr "ПО УМОЛЧАНИЮ"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:275
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:314
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:276
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:315
 msgid "Delete"
 msgstr "Удалить"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:309
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:310
 msgid "Not occupied"
 msgstr "Не занято"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:326
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:327
 msgid "OVERRIDE"
 msgstr "ПЕРЕОПРЕДЕЛИТЬ"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:339
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:340
 msgid "OVERRIDE (ANY)"
 msgstr "ПЕРЕОПРЕДЕЛИТЬ (ЛЮБОЙ)"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:395
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:397
 msgid "Reset Settings"
 msgstr "Сбросить настройки"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:401
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:403
 msgid "Reset all settings to default values"
 msgstr ""
 
@@ -218,6 +218,17 @@ msgstr "Игнорировать рабочее пространство"
 msgid "Do not restore windows' workspace."
 msgstr "Не восстанавливайте окно рабочего пространства."
 
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:69
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:126
+msgid "Ignore Monitor"
+msgstr "Игнорировать монитор"
+
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:70
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:127
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:128
+msgid "Do not restore windows' monitor."
+msgstr ""
+
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:5
 msgid "General"
 msgstr "Общий"
@@ -246,6 +257,6 @@ msgstr "Игнорировать позицию"
 msgid "Ignore Workspace"
 msgstr "Игнорировать рабочее пространство"
 
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:151
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:158
 msgid "Add Application"
 msgstr "Добавить приложение"


### PR DESCRIPTION
Introduces a new setting that allows users to ignore the monitor when automatically moving windows.

This provides flexibility for users who want to manage workspace assignments without affecting window placement across multiple monitors.

The setting is exposed in the preferences UI and its state is properly handled and persisted.
