### PR TITLE
Hide quick settings panel button #24

### DIFF
--- a/SmartAutoMoveNG@lauinger-clan.de/lib/common.js
+++ b/SmartAutoMoveNG@lauinger-clan.de/lib/common.js
@@ -3,6 +3,7 @@
 // setting constants
 export const SETTINGS_KEY_SAVED_WINDOWS = "saved-windows";
 export const SETTINGS_KEY_DEBUG_LOGGING = "debug-logging";
+export const SETTINGS_KEY_QUICKSETTINGS = "quicksettings";
 export const SETTINGS_KEY_STARTUP_DELAY = "startup-delay";
 export const SETTINGS_KEY_SYNC_FREQUENCY = "sync-frequency";
 export const SETTINGS_KEY_SAVE_FREQUENCY = "save-frequency";

--- a/SmartAutoMoveNG@lauinger-clan.de/metadata.json
+++ b/SmartAutoMoveNG@lauinger-clan.de/metadata.json
@@ -10,6 +10,6 @@
     },
     "original-author": "khimaros",
     "gettext-domain": "SmartAutoMoveNG",
-    "version-name": "49.3",
+    "version-name": "49.4",
     "shell-version": ["48", "49"]
 }

--- a/SmartAutoMoveNG@lauinger-clan.de/prefs.js
+++ b/SmartAutoMoveNG@lauinger-clan.de/prefs.js
@@ -119,6 +119,7 @@ export default class SAMPreferences extends ExtensionPreferences {
     _general(settings, builder) {
         const generalBindings = [
             [Common.SETTINGS_KEY_DEBUG_LOGGING, "debug-logging-switch", "active"],
+            [Common.SETTINGS_KEY_QUICKSETTINGS, "quicksettings-switch", "active"],
             [Common.SETTINGS_KEY_SYNC_MODE, "sync-mode-combo", "selected"],
             [Common.SETTINGS_KEY_MATCH_THRESHOLD, "match-threshold-spin", "value"],
             [Common.SETTINGS_KEY_SYNC_FREQUENCY, "sync-frequency-spin", "value"],
@@ -382,6 +383,7 @@ export default class SAMPreferences extends ExtensionPreferences {
             // List all keys you want to reset
             const keys = [
                 Common.SETTINGS_KEY_DEBUG_LOGGING,
+                Common.SETTINGS_KEY_QUICKSETTINGS,
                 Common.SETTINGS_KEY_SYNC_MODE,
                 Common.SETTINGS_KEY_MATCH_THRESHOLD,
                 Common.SETTINGS_KEY_SYNC_FREQUENCY,

--- a/SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml
+++ b/SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml
@@ -14,6 +14,11 @@
       <summary>Debug Logging</summary>
       <description>Write detailed logs about extension behavior.</description>
     </key>
+    <key name="quicksettings" type="b">
+      <default>true</default>
+      <summary>Quicksettings</summary>
+      <description>Show toggle and menu in quicksettings.</description>
+    </key>
     <key name="startup-delay" type="i">
       <default>2500</default>
       <summary>Startup Delay (ms)</summary>

--- a/SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui
+++ b/SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui
@@ -8,6 +8,13 @@
       <object class="AdwPreferencesGroup" id="smartautomove_group1">
         <property name="title" translatable="yes">Settings</property>
         <child>
+          <object class="AdwSwitchRow" id="quicksettings-switch">
+            <property name="title" translatable="yes">Quicksettings</property>
+            <property name="subtitle" translatable="yes">Show toggle and menu in quicksettings.</property>
+            <property name="tooltip-text" translatable="yes">Show toggle and menu in quicksettings.</property>
+          </object>
+        </child>
+        <child>
           <object class="AdwSwitchRow" id="debug-logging-switch">
             <property name="title" translatable="yes">Debug Logging</property>
             <property name="subtitle" translatable="yes">Write detailed logs about extension behavior.</property>

--- a/po/SmartAutoMoveNG.pot
+++ b/po/SmartAutoMoveNG.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-17 15:43+0200\n"
+"POT-Creation-Date: 2025-10-22 20:00+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,12 +20,12 @@ msgstr ""
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:49
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:70
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:9
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:136
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:143
 msgid "Saved Windows"
 msgstr ""
 
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:51
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:143
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:150
 msgid "Cleanup Non-occupied Windows"
 msgstr ""
 
@@ -35,16 +35,16 @@ msgid "Settings"
 msgstr ""
 
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:70
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:44
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:151
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:49
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:158
 msgid "Overrides"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/extension.js:594
+#: SmartAutoMoveNG@lauinger-clan.de/extension.js:615
 msgid "Freeze saves enabled"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/extension.js:597
+#: SmartAutoMoveNG@lauinger-clan.de/extension.js:618
 msgid "Freeze saves disabled"
 msgstr ""
 
@@ -60,51 +60,51 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:189
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:190
 msgid "Select app"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:256
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:357
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:257
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:358
 msgid "ANY"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:280
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:25
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:281
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:32
 msgid "IGNORE"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:281
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:26
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:282
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:33
 msgid "RESTORE"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:282
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:283
 msgid "DEFAULT"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:299
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:336
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:300
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:337
 msgid "Delete"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:331
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:332
 msgid "Not occupied"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:348
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:349
 msgid "OVERRIDE"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:361
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:362
 msgid "OVERRIDE (ANY)"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:418
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:420
 msgid "Reset Settings"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:424
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:426
 msgid "Reset all settings to default values"
 msgstr ""
 
@@ -113,125 +113,136 @@ msgid "Persisted window data serialized to JSON."
 msgstr ""
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:14
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:12
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:19
 msgid "Debug Logging"
 msgstr ""
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:15
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:13
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:14
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:20
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:21
 msgid "Write detailed logs about extension behavior."
 msgstr ""
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:19
-msgid "Startup Delay (ms)"
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:12
+msgid "Quicksettings"
 msgstr ""
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:20
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:83
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:84
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:13
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:14
+msgid "Show toggle and menu in quicksettings."
+msgstr ""
+
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:24
+msgid "Startup Delay (ms)"
+msgstr ""
+
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:25
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:90
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:91
 msgid ""
 "Period of time in milliseconds to wait between seeing a window and writing "
 "it to the in-memory store."
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:24
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:29
 msgid "Sync Frequency (ms)"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:25
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:51
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:52
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:30
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:58
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:59
 msgid ""
 "Frequency in milliseconds to synchronize changes to active windows into the "
 "in-memory store."
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:29
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:34
 msgid "Save Frequency (ms)"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:30
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:67
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:68
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:35
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:74
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:75
 msgid "Frequency in milliseconds to persist the in-memory store to disk."
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:34
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:34
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:39
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:41
 msgid "Match Threshold"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:35
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:35
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:36
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:40
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:42
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:43
 msgid "Minimum threshold for matching restored windows."
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:39
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:44
 msgid "Sync Mode"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:40
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:20
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:21
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:45
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:27
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:28
 msgid "Default mode when synchronizing windows."
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:45
-msgid "Overrides for restored window data."
-msgstr ""
-
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:49
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:98
-msgid "Freeze Saves"
-msgstr ""
-
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:50
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:99
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:100
-msgid "Do not update saved window data."
+msgid "Overrides for restored window data."
 msgstr ""
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:54
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:105
-msgid "Activate Workspace"
+msgid "Freeze Saves"
 msgstr ""
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:55
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:106
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:107
-msgid "Follow apps when they are moved to another workspace."
+msgid "Do not update saved window data."
 msgstr ""
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:59
-msgid "Ignore position"
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:112
+msgid "Activate Workspace"
 msgstr ""
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:60
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:113
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:114
-msgid "Do not restore windows' position."
+msgid "Follow apps when they are moved to another workspace."
 msgstr ""
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:64
-msgid "Ignore workspace"
+msgid "Ignore position"
 msgstr ""
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:65
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:120
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:121
-msgid "Do not restore windows' workspace."
+msgid "Do not restore windows' position."
 msgstr ""
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:69
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:126
-msgid "Ignore monitor"
+msgid "Ignore workspace"
 msgstr ""
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:70
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:127
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:128
+msgid "Do not restore windows' workspace."
+msgstr ""
+
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:74
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:133
+msgid "Ignore monitor"
+msgstr ""
+
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:75
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:134
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:135
 msgid "Do not restore windows' monitor."
 msgstr ""
 
@@ -239,30 +250,30 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:19
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:26
 msgid "Default Synchronization Mode"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:50
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:57
 msgid "Sync Frequency (milliseconds)"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:66
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:73
 msgid "Save Frequency (milliseconds)"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:82
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:89
 msgid "Startup Delay (milliseconds)"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:112
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:119
 msgid "Ignore Position"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:119
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:126
 msgid "Ignore Workspace"
 msgstr ""
 
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:158
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:165
 msgid "Add Application"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-17 15:43+0200\n"
-"PO-Revision-Date: 2025-10-04 09:22+0200\n"
+"POT-Creation-Date: 2025-10-22 20:00+0200\n"
+"PO-Revision-Date: 2025-10-22 20:01+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
 "Language: de\n"
@@ -21,12 +21,12 @@ msgstr ""
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:49
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:70
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:9
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:136
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:143
 msgid "Saved Windows"
 msgstr "Gespeicherte Fenster"
 
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:51
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:143
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:150
 msgid "Cleanup Non-occupied Windows"
 msgstr "Nicht besetzte Fenster aufräumen"
 
@@ -36,16 +36,16 @@ msgid "Settings"
 msgstr "Einstellungen"
 
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:70
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:44
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:151
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:49
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:158
 msgid "Overrides"
 msgstr "Überschreibungen"
 
-#: SmartAutoMoveNG@lauinger-clan.de/extension.js:594
+#: SmartAutoMoveNG@lauinger-clan.de/extension.js:615
 msgid "Freeze saves enabled"
 msgstr "Speichern einfrieren aktiviert"
 
-#: SmartAutoMoveNG@lauinger-clan.de/extension.js:597
+#: SmartAutoMoveNG@lauinger-clan.de/extension.js:618
 msgid "Freeze saves disabled"
 msgstr "Speichern einfrieren deaktiviert"
 
@@ -61,51 +61,51 @@ msgstr "Auswählen"
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:189
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:190
 msgid "Select app"
 msgstr "App auswählen"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:256
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:357
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:257
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:358
 msgid "ANY"
 msgstr "Beliebig"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:280
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:25
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:281
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:32
 msgid "IGNORE"
 msgstr "Ignorieren"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:281
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:26
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:282
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:33
 msgid "RESTORE"
 msgstr "Wiederherstellen"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:282
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:283
 msgid "DEFAULT"
 msgstr "Standard"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:299
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:336
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:300
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:337
 msgid "Delete"
 msgstr "Löschen"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:331
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:332
 msgid "Not occupied"
 msgstr "Nicht besetzt"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:348
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:349
 msgid "OVERRIDE"
 msgstr "Überschreiben"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:361
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:362
 msgid "OVERRIDE (ANY)"
 msgstr "Überschreiben (beliebig)"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:418
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:420
 msgid "Reset Settings"
 msgstr "Einstellungen zurücksetzen"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:424
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:426
 msgid "Reset all settings to default values"
 msgstr "Alle Einstellungen auf Standardwerte zurücksetzen"
 
@@ -114,23 +114,34 @@ msgid "Persisted window data serialized to JSON."
 msgstr "Persistierte Fensterdaten, die in JSON serialisiert wurden."
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:14
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:12
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:19
 msgid "Debug Logging"
 msgstr "Debug-Logging"
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:15
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:13
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:14
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:20
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:21
 msgid "Write detailed logs about extension behavior."
 msgstr "Detaillierte Protokolle über das Verhalten der Erweiterung schreiben."
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:19
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:12
+msgid "Quicksettings"
+msgstr "Quicksettings"
+
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:20
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:13
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:14
+msgid "Show toggle and menu in quicksettings."
+msgstr "Zeige Umschalter und Menü in Quicksettings."
+
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:24
 msgid "Startup Delay (ms)"
 msgstr "Startverzögerung (ms)"
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:20
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:83
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:84
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:25
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:90
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:91
 msgid ""
 "Period of time in milliseconds to wait between seeing a window and writing "
 "it to the in-memory store."
@@ -138,13 +149,13 @@ msgstr ""
 "Zeitraum in Millisekunden, der zwischen dem Erkennen eines Fensters und dem "
 "Schreiben in den In-Memory-Speicher gewartet wird."
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:24
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:29
 msgid "Sync Frequency (ms)"
 msgstr "Synchronisationsfrequenz (ms)"
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:25
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:51
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:52
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:30
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:58
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:59
 msgid ""
 "Frequency in milliseconds to synchronize changes to active windows into the "
 "in-memory store."
@@ -152,94 +163,94 @@ msgstr ""
 "Frequenz in Millisekunden, um Änderungen an aktiven Fenstern in den In-"
 "Memory-Speicher zu synchronisieren."
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:29
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:34
 msgid "Save Frequency (ms)"
 msgstr "Speicherfrequenz (ms)"
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:30
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:67
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:68
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:35
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:74
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:75
 msgid "Frequency in milliseconds to persist the in-memory store to disk."
 msgstr ""
 "Frequenz in Millisekunden, um den In-Memory-Speicher auf die Festplatte zu "
 "persistieren."
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:34
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:34
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:39
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:41
 msgid "Match Threshold"
 msgstr "Übereinstimmungsschwelle"
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:35
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:35
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:36
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:40
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:42
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:43
 msgid "Minimum threshold for matching restored windows."
 msgstr "Mindestschwelle für die Übereinstimmung wiederhergestellter Fenster."
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:39
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:44
 msgid "Sync Mode"
 msgstr "Synchronisationsmodus"
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:40
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:20
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:21
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:45
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:27
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:28
 msgid "Default mode when synchronizing windows."
 msgstr "Standardmodus beim Synchronisieren von Fenstern."
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:45
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:50
 msgid "Overrides for restored window data."
 msgstr "Überschreibungen für wiederhergestellte Fensterdaten."
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:49
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:98
-msgid "Freeze Saves"
-msgstr "Speichern einfrieren"
-
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:50
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:99
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:100
-msgid "Do not update saved window data."
-msgstr "Gespeicherte Fensterdaten nicht aktualisieren."
-
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:54
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:105
-msgid "Activate Workspace"
-msgstr "Arbeitsbereich aktivieren"
+msgid "Freeze Saves"
+msgstr "Speichern einfrieren"
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:55
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:106
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:107
-msgid "Follow apps when they are moved to another workspace."
-msgstr ""
-"Apps folgen, wenn sie in einen anderen Arbeitsbereich verschoben werden."
+msgid "Do not update saved window data."
+msgstr "Gespeicherte Fensterdaten nicht aktualisieren."
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:59
-msgid "Ignore position"
-msgstr "Position ignorieren"
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:112
+msgid "Activate Workspace"
+msgstr "Arbeitsbereich aktivieren"
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:60
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:113
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:114
-msgid "Do not restore windows' position."
-msgstr "Fensterposition nicht wiederherstellen."
+msgid "Follow apps when they are moved to another workspace."
+msgstr ""
+"Apps folgen, wenn sie in einen anderen Arbeitsbereich verschoben werden."
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:64
-msgid "Ignore workspace"
-msgstr "Arbeitsbereich ignorieren"
+msgid "Ignore position"
+msgstr "Position ignorieren"
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:65
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:120
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:121
-msgid "Do not restore windows' workspace."
-msgstr "Arbeitsbereich der Fenster nicht wiederherstellen."
+msgid "Do not restore windows' position."
+msgstr "Fensterposition nicht wiederherstellen."
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:69
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:126
-msgid "Ignore monitor"
-msgstr "Monitor ignorieren"
+msgid "Ignore workspace"
+msgstr "Arbeitsbereich ignorieren"
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:70
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:127
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:128
+msgid "Do not restore windows' workspace."
+msgstr "Arbeitsbereich der Fenster nicht wiederherstellen."
+
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:74
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:133
+msgid "Ignore monitor"
+msgstr "Monitor ignorieren"
+
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:75
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:134
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:135
 msgid "Do not restore windows' monitor."
 msgstr "Monitor der Fenster nicht wiederherstellen."
 
@@ -247,31 +258,31 @@ msgstr "Monitor der Fenster nicht wiederherstellen."
 msgid "General"
 msgstr "Allgemein"
 
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:19
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:26
 msgid "Default Synchronization Mode"
 msgstr "Standard-Synchronisationsmodus"
 
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:50
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:57
 msgid "Sync Frequency (milliseconds)"
 msgstr "Synchronisationsfrequenz (Millisekunden)"
 
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:66
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:73
 msgid "Save Frequency (milliseconds)"
 msgstr "Speicherfrequenz (Millisekunden)"
 
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:82
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:89
 msgid "Startup Delay (milliseconds)"
 msgstr "Startverzögerung (Millisekunden)"
 
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:112
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:119
 msgid "Ignore Position"
 msgstr "Position ignorieren"
 
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:119
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:126
 msgid "Ignore Workspace"
 msgstr "Arbeitsbereich ignorieren"
 
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:158
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:165
 msgid "Add Application"
 msgstr "Anwendung hinzufügen"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-17 15:43+0200\n"
-"PO-Revision-Date: 2025-10-04 09:18+0200\n"
+"POT-Creation-Date: 2025-10-22 20:00+0200\n"
+"PO-Revision-Date: 2025-10-22 20:01+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: RU <LL@li.org>\n"
 "Language: ru\n"
@@ -21,12 +21,12 @@ msgstr ""
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:49
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:70
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:9
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:136
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:143
 msgid "Saved Windows"
 msgstr "Сохраненные окна"
 
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:51
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:143
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:150
 msgid "Cleanup Non-occupied Windows"
 msgstr "Очистка незанятых окон"
 
@@ -36,16 +36,16 @@ msgid "Settings"
 msgstr "Настройки"
 
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:70
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:44
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:151
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:49
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:158
 msgid "Overrides"
 msgstr "Переопределить"
 
-#: SmartAutoMoveNG@lauinger-clan.de/extension.js:594
+#: SmartAutoMoveNG@lauinger-clan.de/extension.js:615
 msgid "Freeze saves enabled"
 msgstr "Заморозить Сохранить включенный"
 
-#: SmartAutoMoveNG@lauinger-clan.de/extension.js:597
+#: SmartAutoMoveNG@lauinger-clan.de/extension.js:618
 msgid "Freeze saves disabled"
 msgstr "Заморозить Сохранить инвалид"
 
@@ -61,51 +61,51 @@ msgstr "Выбрать"
 msgid "Cancel"
 msgstr "Отмена"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:189
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:190
 msgid "Select app"
 msgstr "Приложение"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:256
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:357
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:257
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:358
 msgid "ANY"
 msgstr "ЛЮБОЙ"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:280
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:25
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:281
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:32
 msgid "IGNORE"
 msgstr "ИГНОРИРОВАТЬ"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:281
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:26
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:282
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:33
 msgid "RESTORE"
 msgstr "ВОССТАНОВИТЬ"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:282
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:283
 msgid "DEFAULT"
 msgstr "ПО УМОЛЧАНИЮ"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:299
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:336
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:300
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:337
 msgid "Delete"
 msgstr "Удалить"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:331
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:332
 msgid "Not occupied"
 msgstr "Не занято"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:348
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:349
 msgid "OVERRIDE"
 msgstr "ПЕРЕОПРЕДЕЛИТЬ"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:361
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:362
 msgid "OVERRIDE (ANY)"
 msgstr "ПЕРЕОПРЕДЕЛИТЬ (ЛЮБОЙ)"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:418
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:420
 msgid "Reset Settings"
 msgstr "Сбросить настройки"
 
-#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:424
+#: SmartAutoMoveNG@lauinger-clan.de/prefs.js:426
 msgid "Reset all settings to default values"
 msgstr ""
 
@@ -114,23 +114,34 @@ msgid "Persisted window data serialized to JSON."
 msgstr "Сохраненные данные окна сериализованы в JSON."
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:14
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:12
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:19
 msgid "Debug Logging"
 msgstr "Журнал"
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:15
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:13
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:14
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:20
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:21
 msgid "Write detailed logs about extension behavior."
 msgstr "Вести подробный журналы о поведении расширения."
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:19
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:12
+msgid "Quicksettings"
+msgstr ""
+
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:20
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:13
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:14
+msgid "Show toggle and menu in quicksettings."
+msgstr ""
+
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:24
 msgid "Startup Delay (ms)"
 msgstr "Задержка запуска (мсек)"
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:20
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:83
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:84
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:25
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:90
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:91
 msgid ""
 "Period of time in milliseconds to wait between seeing a window and writing "
 "it to the in-memory store."
@@ -138,13 +149,13 @@ msgstr ""
 "Период времени в миллисекундах между просмотром окна и записью его в "
 "хранилище памяти."
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:24
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:29
 msgid "Sync Frequency (ms)"
 msgstr "Частота синхронизации (мсек)"
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:25
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:51
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:52
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:30
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:58
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:59
 msgid ""
 "Frequency in milliseconds to synchronize changes to active windows into the "
 "in-memory store."
@@ -152,92 +163,92 @@ msgstr ""
 "Частота в миллисекундах для синхронизации изменений в активных окнах в "
 "хранилище памяти."
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:29
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:34
 msgid "Save Frequency (ms)"
 msgstr "Частота сохранения (мсек)"
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:30
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:67
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:68
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:35
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:74
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:75
 msgid "Frequency in milliseconds to persist the in-memory store to disk."
 msgstr "Частота в миллисекундах для сохранения содержимого памяти на диске."
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:34
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:34
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:39
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:41
 msgid "Match Threshold"
 msgstr "Порог соответствия"
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:35
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:35
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:36
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:40
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:42
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:43
 msgid "Minimum threshold for matching restored windows."
 msgstr "Минимальный порог для сопоставления восстановленных окон."
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:39
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:44
 msgid "Sync Mode"
 msgstr "Режим синхронизации"
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:40
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:20
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:21
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:45
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:27
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:28
 msgid "Default mode when synchronizing windows."
 msgstr "Режим по умолчанию при синхронизации окон."
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:45
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:50
 msgid "Overrides for restored window data."
 msgstr "Переопределения для восстановленных данных окна."
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:49
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:98
-msgid "Freeze Saves"
-msgstr "Заморозить Сохранить"
-
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:50
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:99
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:100
-msgid "Do not update saved window data."
-msgstr "Не обновлять сохраненные данные окна."
-
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:54
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:105
-msgid "Activate Workspace"
-msgstr "Активировать рабочее пространство"
+msgid "Freeze Saves"
+msgstr "Заморозить Сохранить"
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:55
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:106
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:107
-msgid "Follow apps when they are moved to another workspace."
-msgstr ""
-"Отслеживайте приложения при их перемещении в другое рабочее пространство."
+msgid "Do not update saved window data."
+msgstr "Не обновлять сохраненные данные окна."
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:59
-msgid "Ignore position"
-msgstr "Игнорировать позицию"
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:112
+msgid "Activate Workspace"
+msgstr "Активировать рабочее пространство"
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:60
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:113
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:114
-msgid "Do not restore windows' position."
-msgstr "Не восстанавливайте положение окон."
+msgid "Follow apps when they are moved to another workspace."
+msgstr ""
+"Отслеживайте приложения при их перемещении в другое рабочее пространство."
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:64
-msgid "Ignore workspace"
-msgstr "Игнорировать рабочее пространство"
+msgid "Ignore position"
+msgstr "Игнорировать позицию"
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:65
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:120
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:121
-msgid "Do not restore windows' workspace."
-msgstr "Не восстанавливайте окно рабочего пространства."
+msgid "Do not restore windows' position."
+msgstr "Не восстанавливайте положение окон."
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:69
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:126
-msgid "Ignore monitor"
-msgstr "Игнорировать монитор"
+msgid "Ignore workspace"
+msgstr "Игнорировать рабочее пространство"
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:70
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:127
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:128
+msgid "Do not restore windows' workspace."
+msgstr "Не восстанавливайте окно рабочего пространства."
+
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:74
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:133
+msgid "Ignore monitor"
+msgstr "Игнорировать монитор"
+
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:75
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:134
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:135
 msgid "Do not restore windows' monitor."
 msgstr ""
 
@@ -245,31 +256,31 @@ msgstr ""
 msgid "General"
 msgstr "Общий"
 
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:19
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:26
 msgid "Default Synchronization Mode"
 msgstr "Режим синхронизации по умолчанию"
 
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:50
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:57
 msgid "Sync Frequency (milliseconds)"
 msgstr "Частота синхронизации (мсек)"
 
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:66
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:73
 msgid "Save Frequency (milliseconds)"
 msgstr "Частота сохранения (мсек)"
 
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:82
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:89
 msgid "Startup Delay (milliseconds)"
 msgstr "Задержка запуска (мсек)"
 
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:112
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:119
 msgid "Ignore Position"
 msgstr "Игнорировать позицию"
 
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:119
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:126
 msgid "Ignore Workspace"
 msgstr "Игнорировать рабочее пространство"
 
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:158
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:165
 msgid "Add Application"
 msgstr "Добавить приложение"
 


### PR DESCRIPTION
Adds a toggle in the quick settings panel to enable/disable the extension's functionality.

This allows users to easily control the extension without needing to open the settings.
A new setting is added to control the indicator.
The OSD notification and menu title updates are now dependent on the quick settings toggle being enabled.

Fixes #24
