### PR TITLE
"TypeError: this._indicator is null" error #28

### DIFF
--- a/SmartAutoMoveNG@lauinger-clan.de/extension.js
+++ b/SmartAutoMoveNG@lauinger-clan.de/extension.js
@@ -170,8 +170,10 @@ export default class SmartAutoMoveNG extends Extension {
         this._saveSettings();
         this._cleanupSettings();
         this._activeWindows = null;
-        this._indicator.destroy();
-        this._indicator = null;
+        if (this._indicator !== null) {
+            this._indicator.destroy();
+            this._indicator = null;
+        }
         this._isGnome49OrHigher = null;
     }
 

--- a/SmartAutoMoveNG@lauinger-clan.de/metadata.json
+++ b/SmartAutoMoveNG@lauinger-clan.de/metadata.json
@@ -10,6 +10,6 @@
     },
     "original-author": "khimaros",
     "gettext-domain": "SmartAutoMoveNG",
-    "version-name": "49.5",
+    "version-name": "49.6",
     "shell-version": ["48", "49"]
 }


### PR DESCRIPTION
Updates the extension version to reflect changes.

Ensures the indicator is properly destroyed only if it exists,
preventing potential errors during extension disabling.
