### PR TITLE
Simplifies icon loading logic

### DIFF
--- a/SmartAutoMoveNG@lauinger-clan.de/extension.js
+++ b/SmartAutoMoveNG@lauinger-clan.de/extension.js
@@ -169,13 +169,13 @@ export default class SmartAutoMoveNG extends Extension {
 
     _getMenuIcon() {
         const SmartAutoMoveNGIcon = "smartautomoveng-symbolic";
-        let finalMenuIcon = SmartAutoMoveNGIcon;
-        this._iconTheme = new St.IconTheme();
-        if (!this._iconTheme.has_icon(SmartAutoMoveNGIcon)) {
-            const IconPath = "/icons/";
-            finalMenuIcon = Gio.icon_new_for_string(`${this.path}${IconPath}${SmartAutoMoveNGIcon}.svg`);
+        const iconTheme = new St.IconTheme();
+        if (iconTheme.has_icon(SmartAutoMoveNGIcon)) {
+            return Gio.icon_new_for_string(SmartAutoMoveNGIcon);
+        } else {
+            const iconPath = "/icons/";
+            return Gio.icon_new_for_string(`${this.path}${iconPath}${SmartAutoMoveNGIcon}.svg`);
         }
-        return finalMenuIcon;
     }
 
     _openPreferences() {
@@ -565,7 +565,7 @@ export default class SmartAutoMoveNG extends Extension {
     _handleChangedFreezeSaves() {
         this._freezeSaves = this._settings.get_boolean(Common.SETTINGS_KEY_FREEZE_SAVES);
         if (this._notifications) {
-            this._sendOSDNotification(_("Freeze saves"), this._freezeSaves);
+            this._sendOSDNotification(_("Freeze Saves"), this._freezeSaves);
         }
         this._debug("_handleChangedFreezeSaves(): " + this._freezeSaves);
     }

--- a/po/SmartAutoMoveNG.pot
+++ b/po/SmartAutoMoveNG.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-03 19:04+0100\n"
+"POT-Creation-Date: 2025-11-03 22:48+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -47,7 +47,9 @@ msgid "Debug Logging"
 msgstr ""
 
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:568
-msgid "Freeze saves"
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:59
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:117
+msgid "Freeze Saves"
 msgstr ""
 
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:577
@@ -227,11 +229,6 @@ msgstr ""
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:55
 msgid "Overrides for restored window data."
-msgstr ""
-
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:59
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:117
-msgid "Freeze Saves"
 msgstr ""
 
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:60

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-03 19:04+0100\n"
+"POT-Creation-Date: 2025-11-03 22:48+0100\n"
 "PO-Revision-Date: 2025-11-03 19:04+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
@@ -48,7 +48,9 @@ msgid "Debug Logging"
 msgstr "Debug-Logging"
 
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:568
-msgid "Freeze saves"
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:59
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:117
+msgid "Freeze Saves"
 msgstr "Speichern einfrieren"
 
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:577
@@ -236,11 +238,6 @@ msgstr "Standardmodus beim Synchronisieren von Fenstern."
 msgid "Overrides for restored window data."
 msgstr "Überschreibungen für wiederhergestellte Fensterdaten."
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:59
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:117
-msgid "Freeze Saves"
-msgstr "Speichern einfrieren"
-
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:60
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:118
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:119
@@ -312,6 +309,9 @@ msgstr "Startverzögerung (Millisekunden)"
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:177
 msgid "Add Application"
 msgstr "Anwendung hinzufügen"
+
+#~ msgid "Freeze saves"
+#~ msgstr "Speichern einfrieren"
 
 #~ msgid "Freeze saves enabled"
 #~ msgstr "Speichern einfrieren aktiviert"

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-03 19:04+0100\n"
+"POT-Creation-Date: 2025-11-03 22:48+0100\n"
 "PO-Revision-Date: 2025-11-03 19:05+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
@@ -48,7 +48,9 @@ msgid "Debug Logging"
 msgstr "Journalisation du débogage"
 
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:568
-msgid "Freeze saves"
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:59
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:117
+msgid "Freeze Saves"
 msgstr "Geler les sauvegardes"
 
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:577
@@ -235,11 +237,6 @@ msgstr "Mode par défaut lors de la synchronisation des fenêtres."
 msgid "Overrides for restored window data."
 msgstr "Remplacements pour les données de fenêtre restaurées."
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:59
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:117
-msgid "Freeze Saves"
-msgstr "Geler les sauvegardes"
-
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:60
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:118
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:119
@@ -312,6 +309,9 @@ msgstr "Délai de démarrage (millisecondes)"
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:177
 msgid "Add Application"
 msgstr "Ajouter une application"
+
+#~ msgid "Freeze saves"
+#~ msgstr "Geler les sauvegardes"
 
 #~ msgid "Freeze saves enabled"
 #~ msgstr "Gel des sauvegardes activé"

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-03 19:04+0100\n"
+"POT-Creation-Date: 2025-11-03 22:48+0100\n"
 "PO-Revision-Date: 2025-11-03 17:52+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: RU <LL@li.org>\n"
@@ -48,7 +48,9 @@ msgid "Debug Logging"
 msgstr "Журнал"
 
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:568
-msgid "Freeze saves"
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:59
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:117
+msgid "Freeze Saves"
 msgstr "Заморозить Сохранить"
 
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:577
@@ -234,11 +236,6 @@ msgstr "Режим по умолчанию при синхронизации о�
 msgid "Overrides for restored window data."
 msgstr "Переопределения для восстановленных данных окна."
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:59
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:117
-msgid "Freeze Saves"
-msgstr "Заморозить Сохранить"
-
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:60
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:118
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:119
@@ -310,6 +307,9 @@ msgstr "Задержка запуска (мсек)"
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:177
 msgid "Add Application"
 msgstr "Добавить приложение"
+
+#~ msgid "Freeze saves"
+#~ msgstr "Заморозить Сохранить"
 
 #~ msgid "Freeze saves enabled"
 #~ msgstr "Заморозить Сохранить включенный"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-03 19:04+0100\n"
+"POT-Creation-Date: 2025-11-03 22:48+0100\n"
 "PO-Revision-Date: 2025-11-03 17:53+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
@@ -49,7 +49,9 @@ msgid "Debug Logging"
 msgstr "调试日志"
 
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:568
-msgid "Freeze saves"
+#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:59
+#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:117
+msgid "Freeze Saves"
 msgstr "暂停记录"
 
 #: SmartAutoMoveNG@lauinger-clan.de/extension.js:577
@@ -231,11 +233,6 @@ msgstr "识别到新窗口时的默认处理模式。"
 msgid "Overrides for restored window data."
 msgstr "为特定窗口设定自定义规则。"
 
-#: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:59
-#: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:117
-msgid "Freeze Saves"
-msgstr "暂停记录"
-
 #: SmartAutoMoveNG@lauinger-clan.de/schemas/org.gnome.shell.extensions.SmartAutoMoveNG.gschema.xml:60
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:118
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:119
@@ -306,6 +303,9 @@ msgstr "启动延迟 (毫秒)"
 #: SmartAutoMoveNG@lauinger-clan.de/ui/prefs-adw.ui:177
 msgid "Add Application"
 msgstr "添加应用程序"
+
+#~ msgid "Freeze saves"
+#~ msgstr "暂停记录"
 
 #~ msgid "Freeze saves enabled"
 #~ msgstr "暂停记录窗口位置"


### PR DESCRIPTION
Refactors the `_getMenuIcon` method to streamline the icon loading process.

It now directly returns the icon if it exists in the current theme, otherwise, it constructs the icon path. This avoids unnecessary variable assignments and improves readability.
