### PR TITLE
Refactors code for const usage

### DIFF
--- a/SmartAutoMoveNG@lauinger-clan.de/extension.js
+++ b/SmartAutoMoveNG@lauinger-clan.de/extension.js
@@ -193,14 +193,14 @@ export default class SmartAutoMoveNG extends Extension {
 
     _dumpSavedWindows() {
         for (const wsh of Object.keys(this._savedWindows)) {
-            let sws = this._savedWindows[wsh];
+            const sws = this._savedWindows[wsh];
             this._debug("_dumpSavedwindows(): " + wsh + " " + JSON.stringify(sws));
         }
     }
 
     _dumpCurrentWindows() {
         for (const actor of global.get_window_actors()) {
-            let win = actor.get_meta_window();
+            const win = actor.get_meta_window();
             this._dumpWindow(win);
         }
     }
@@ -268,13 +268,13 @@ export default class SmartAutoMoveNG extends Extension {
     //// WINDOW UTILITIES
 
     _windowReady(win) {
-        let win_rect = win.get_frame_rect();
+        const win_rect = win.get_frame_rect();
         return !(win_rect.width === 0 && win_rect.height === 0) && !(win_rect.x === 0 && win_rect.y === 0);
     }
 
     // https://gjs-docs-experimental.web.app/meta-10/Window/
     _windowData(win) {
-        let win_rect = win.get_frame_rect();
+        const win_rect = win.get_frame_rect();
         return {
             id: win.get_id(),
             hash: this._windowHash(win),
@@ -315,7 +315,7 @@ export default class SmartAutoMoveNG extends Extension {
     }
 
     _windowNewerThan(win, age) {
-        let wh = this._windowHash(win);
+        const wh = this._windowHash(win);
 
         if (this._activeWindows.get(wh) === undefined) {
             this._activeWindows.set(wh, Date.now());
@@ -327,20 +327,20 @@ export default class SmartAutoMoveNG extends Extension {
     //// WINDOW SAVE / RESTORE
 
     _pushSavedWindow(win) {
-        let wsh = this._windowSectionHash(win);
+        const wsh = this._windowSectionHash(win);
         if (wsh === null) return false;
         if (!Object.hasOwn(this._savedWindows, wsh)) this._savedWindows[wsh] = [];
-        let sw = this._windowData(win);
+        const sw = this._windowData(win);
         this._savedWindows[wsh].push(sw);
         this._debug("_pushSavedWindow() - pushed: " + JSON.stringify(sw));
         return true;
     }
 
     _updateSavedWindow(win) {
-        let wsh = this._windowSectionHash(win);
-        let [swi] = Common.findSavedWindow(this._savedWindows, wsh, { hash: this._windowHash(win) }, 1);
+        const wsh = this._windowSectionHash(win);
+        const [swi] = Common.findSavedWindow(this._savedWindows, wsh, { hash: this._windowHash(win) }, 1);
         if (swi === undefined) return false;
-        let sw = this._windowData(win);
+        const sw = this._windowData(win);
         if (this._windowDataEqual(this._savedWindows[wsh][swi], sw)) return true;
         this._savedWindows[wsh][swi] = sw;
         this._debug("_updateSavedWindow() - updated: " + swi + ", " + JSON.stringify(sw));
@@ -358,12 +358,12 @@ export default class SmartAutoMoveNG extends Extension {
     }
 
     _findOverrideAction(win, threshold) {
-        let wsh = this._windowSectionHash(win);
-        let sw = this._windowData(win);
+        const wsh = this._windowSectionHash(win);
+        const sw = this._windowData(win);
 
         let action = this._syncMode;
 
-        let override = Common.findOverride(this._overrides, wsh, sw, threshold);
+        const override = Common.findOverride(this._overrides, wsh, sw, threshold);
 
         if (override !== undefined && override.action !== undefined) action = override.action;
 
@@ -375,14 +375,14 @@ export default class SmartAutoMoveNG extends Extension {
             win.move_to_monitor(sw.monitor);
         }
 
-        let ws = global.workspaceManager.get_workspace_by_index(sw.workspace);
+        const ws = global.workspaceManager.get_workspace_by_index(sw.workspace);
         if (!this._ignoreWorkspace) {
             if (ws !== null) win.change_workspace(ws);
             this._debug("_moveWindow to workspace: " + ws);
         }
 
         if (this._ignorePosition) {
-            let cw = this._windowData(win);
+            const cw = this._windowData(win);
             sw.x = cw.x;
             sw.y = cw.y;
         }
@@ -405,13 +405,13 @@ export default class SmartAutoMoveNG extends Extension {
 
         if (sw.on_all_workspaces) win.stick();
 
-        let nsw = this._windowData(win);
+        const nsw = this._windowData(win);
 
         return nsw;
     }
 
     _restoreWindow(win) {
-        let wsh = this._windowSectionHash(win);
+        const wsh = this._windowSectionHash(win);
 
         let sw;
 
@@ -433,12 +433,12 @@ export default class SmartAutoMoveNG extends Extension {
 
         if (this._windowDataEqual(sw, this._windowData(win))) return true;
 
-        let action = this._findOverrideAction(win, 1);
+        const action = this._findOverrideAction(win, 1);
         if (action !== Common.SYNC_MODE_RESTORE) return true;
 
-        let pWinRepr = this._windowRepr(win);
+        const pWinRepr = this._windowRepr(win);
 
-        let nsw = this._moveWindow(win, sw);
+        const nsw = this._moveWindow(win, sw);
 
         if (!this._ignorePosition) {
             if (!(sw.x === nsw.x && sw.y === nsw.y)) return true;
@@ -452,15 +452,15 @@ export default class SmartAutoMoveNG extends Extension {
     }
 
     _cleanupWindows() {
-        let found = new Map();
+        const found = new Map();
 
         for (const actor of global.get_window_actors()) {
-            let win = actor.get_meta_window();
+            const win = actor.get_meta_window();
             found.set(this._windowHash(win), true);
         }
 
         for (const wsh of Object.keys(this._savedWindows)) {
-            let sws = this._savedWindows[wsh];
+            const sws = this._savedWindows[wsh];
             for (const sw of sws) {
                 if (sw.occupied && !found.has(sw.hash)) {
                     sw.occupied = false;
@@ -472,16 +472,14 @@ export default class SmartAutoMoveNG extends Extension {
 
     _shouldSkipWindow(win) {
         const shouldSkip = win.is_skip_taskbar() || win.get_window_type() !== Meta.WindowType.NORMAL;
-        if (this._debugLogging) {
-            this._debug(`_shouldSkipWindow() ${win.get_title()} - skip: ${shouldSkip}`);
-        }
+        this._debug(`_shouldSkipWindow() ${win.get_title()} - skip: ${shouldSkip}`);
         return shouldSkip;
     }
 
     _syncWindows() {
         this._cleanupWindows();
         for (const actor of global.get_window_actors()) {
-            let win = actor.get_meta_window();
+            const win = actor.get_meta_window();
 
             if (this._shouldSkipWindow(win)) continue;
 

--- a/SmartAutoMoveNG@lauinger-clan.de/lib/common.js
+++ b/SmartAutoMoveNG@lauinger-clan.de/lib/common.js
@@ -50,9 +50,9 @@ export function scoreWindow(sw, query) {
     let match_parts = 0;
     let query_parts = 0;
     for (const key of Object.keys(query)) {
-        let value = query[key];
+        const value = query[key];
         if (key === "title") {
-            let dist = levensteinDistance(value, sw[key]);
+            const dist = levensteinDistance(value, sw[key]);
             let title_score = (value.length - dist) / value.length;
             if (title_score < 0) title_score = -0.3;
             match_parts += title_score;
@@ -71,16 +71,15 @@ export function findSavedWindow(saved_windows, wsh, query, threshold) {
         return [undefined, undefined];
     }
 
-    let scores = new Map();
+    const scores = new Map();
     for (const [swi, sw] of saved_windows[wsh].entries()) {
-        let score = scoreWindow(sw, query);
+        const score = scoreWindow(sw, query);
         scores.set(swi, score);
     }
 
-    let sorted_scores = new Map([...scores.entries()].sort((a, b) => b[1] - a[1]));
-
-    let best_swi = sorted_scores.keys().next().value;
-    let best_score = sorted_scores.get(best_swi);
+    const sorted_scores = new Map([...scores.entries()].sort((a, b) => b[1] - a[1]));
+    const best_swi = sorted_scores.keys().next().value;
+    const best_score = sorted_scores.get(best_swi);
 
     let found;
     if (best_score >= threshold) {
@@ -93,7 +92,7 @@ export function findSavedWindow(saved_windows, wsh, query, threshold) {
 }
 
 export function findOverride(overrides, wsh, sw, threshold) {
-    let override = {};
+    const override = {};
 
     if (!Object.hasOwn(overrides, wsh)) {
         return override;
@@ -104,7 +103,7 @@ export function findOverride(overrides, wsh, sw, threshold) {
             override.threshold = o.threshold;
             break;
         }
-        let score = scoreWindow(sw, o.query);
+        const score = scoreWindow(sw, o.query);
         if (score >= threshold) {
             override.action = o.action;
             override.threshold = o.threshold;
@@ -116,16 +115,16 @@ export function findOverride(overrides, wsh, sw, threshold) {
 }
 
 export function matchedWindow(saved_windows, overrides, wsh, title, default_match_threshold) {
-    let o = findOverride(overrides, wsh, { title: title }, 1);
+    const o = findOverride(overrides, wsh, { title: title }, 1);
 
     let threshold = default_match_threshold;
     if (o !== undefined && o.threshold !== undefined) threshold = o.threshold;
 
-    let [swi] = findSavedWindow(saved_windows, wsh, { title: title, occupied: false }, threshold);
+    const [swi] = findSavedWindow(saved_windows, wsh, { title: title, occupied: false }, threshold);
 
     if (swi === undefined) return [undefined, undefined];
 
-    let sw = saved_windows[wsh][swi];
+    const sw = saved_windows[wsh][swi];
 
     return [swi, sw];
 }
@@ -133,7 +132,7 @@ export function matchedWindow(saved_windows, overrides, wsh, title, default_matc
 export function cleanupNonOccupiedWindows(settings) {
     const saved_windows = JSON.parse(settings.get_string(SETTINGS_KEY_SAVED_WINDOWS));
     for (const wsh of Object.keys(saved_windows)) {
-        let sws = saved_windows[wsh];
+        const sws = saved_windows[wsh];
         saved_windows[wsh] = sws.filter((sw) => sw.occupied);
         if (saved_windows[wsh].length < 1) {
             delete saved_windows[wsh];


### PR DESCRIPTION
Updates the code to use `const` instead of `let` for variables that are not reassigned.
This improves code readability and helps prevent accidental modification of these variables.
