### PR TITLE
Prevents null reference and updates version #44

### DIFF
--- a/SmartAutoMoveNG@lauinger-clan.de/extension.js
+++ b/SmartAutoMoveNG@lauinger-clan.de/extension.js
@@ -567,8 +567,9 @@ export default class SmartAutoMoveNG extends Extension {
         this._debug("_onParamChangedUI() Quick Settings: " + this._quickSettings);
         this._notifications = this._settings.get_boolean(Common.SETTINGS_KEY_NOTIFICATIONS);
         this._debug("_onParamChangedUI() Notifications: " + this._notifications);
-        Gio.Settings.unbind(this._indicator?.menuToggle, "checked");
-        this._indicator?.menuToggle.bindToggleToSetting(this._settings);
+        if (this._indicator === null) return;
+        Gio.Settings.unbind(this._indicator.menuToggle, "checked");
+        this._indicator.menuToggle.bindToggleToSetting(this._settings);
     }
 
     _onParamChangedStartupDelay() {

--- a/SmartAutoMoveNG@lauinger-clan.de/metadata.json
+++ b/SmartAutoMoveNG@lauinger-clan.de/metadata.json
@@ -10,6 +10,6 @@
     },
     "original-author": "khimaros",
     "gettext-domain": "SmartAutoMoveNG",
-    "version-name": "49.11",
+    "version-name": "49.12",
     "shell-version": ["48", "49"]
 }


### PR DESCRIPTION
Adds a null check to prevent errors when the indicator is not initialized.

Updates the extension version to reflect the changes.
