### PR TITLE
Skips window synchronization when screen is locked

### DIFF
--- a/SmartAutoMoveNG@lauinger-clan.de/extension.js
+++ b/SmartAutoMoveNG@lauinger-clan.de/extension.js
@@ -377,6 +377,7 @@ export default class SmartAutoMoveNG extends Extension {
     }
 
     _windowNewerThan(win, age) {
+        if (this._activeWindows === null) return false;
         const wh = this._windowHash(win);
 
         if (this._activeWindows.get(wh) === undefined) {

--- a/SmartAutoMoveNG@lauinger-clan.de/metadata.json
+++ b/SmartAutoMoveNG@lauinger-clan.de/metadata.json
@@ -12,5 +12,5 @@
         "paypal": "ChrisLauinger"
     },
     "version": 999,
-    "version-name": "50.6"
+    "version-name": "50.7"
 }


### PR DESCRIPTION
Prevents the extension from attempting to move windows while the screen shield is active or the session is locked, avoiding potential errors or unexpected behavior during background synchronization.
