### PR TITLE
Prevents error when checking screen shield or session lock

### DIFF
--- a/SmartAutoMoveNG@lauinger-clan.de/extension.js
+++ b/SmartAutoMoveNG@lauinger-clan.de/extension.js
@@ -607,7 +607,7 @@ export default class SmartAutoMoveNG extends Extension {
         if (this._timeoutSyncSignal !== null) GLib.Source.remove(this._timeoutSyncSignal);
         this._timeoutSyncSignal = null;
         try {
-            if (Main.screenShield.active || Main.sessionMode.isLocked) {
+            if (Main.screenShield?.active || Main.sessionMode?.isLocked) {
                 this.getLogger().warn("_handleTimeoutSync() skipped: screen shield active or session locked");
             } else {
                 await this._syncWindows();

--- a/SmartAutoMoveNG@lauinger-clan.de/metadata.json
+++ b/SmartAutoMoveNG@lauinger-clan.de/metadata.json
@@ -12,5 +12,5 @@
         "paypal": "ChrisLauinger"
     },
     "version": 999,
-    "version-name": "50.7"
+    "version-name": "50.8"
 }


### PR DESCRIPTION
Adds optional chaining when accessing Main.screenShield and Main.sessionMode to avoid potential crashes if these objects are undefined. Bumps version to 50.8.

Fixes #63
