### PR TITLE
Conditionally log `_handleTimeoutSync` skip warning

### DIFF
--- a/SmartAutoMoveNG@lauinger-clan.de/extension.js
+++ b/SmartAutoMoveNG@lauinger-clan.de/extension.js
@@ -608,7 +608,8 @@ export default class SmartAutoMoveNG extends Extension {
         this._timeoutSyncSignal = null;
         try {
             if (Main.screenShield?.active || Main.sessionMode?.isLocked) {
-                this.getLogger().warn("_handleTimeoutSync() skipped: screen shield active or session locked");
+                if (this._debugLogging)
+                    this.getLogger().warn("_handleTimeoutSync() skipped: screen shield active or session locked");
             } else {
                 await this._syncWindows();
             }

--- a/SmartAutoMoveNG@lauinger-clan.de/metadata.json
+++ b/SmartAutoMoveNG@lauinger-clan.de/metadata.json
@@ -13,5 +13,5 @@
         "paypal": "ChrisLauinger"
     },
     "version": 999,
-    "version-name": "50.8"
+    "version-name": "50.9"
 }


### PR DESCRIPTION
The warning about `_handleTimeoutSync` being skipped due to a locked session or screen shield is now only logged when `_debugLogging` is active, reducing unnecessary log noise during normal operation.
