### PR TITLE
Uses InjectionManager for workspace method override and removes deprecated GNOME version checks

### DIFF
--- a/SmartAutoMoveNG@lauinger-clan.de/extension.js
+++ b/SmartAutoMoveNG@lauinger-clan.de/extension.js
@@ -7,7 +7,7 @@ import Gio from "gi://Gio";
 import GObject from "gi://GObject";
 import St from "gi://St";
 
-import { Extension, gettext as _ } from "resource:///org/gnome/shell/extensions/extension.js";
+import { Extension, InjectionManager, gettext as _ } from "resource:///org/gnome/shell/extensions/extension.js";
 import * as QuickSettings from "resource:///org/gnome/shell/ui/quickSettings.js";
 import * as Main from "resource:///org/gnome/shell/ui/main.js";
 import { PopupAnimation } from "resource:///org/gnome/shell/ui/boxpointer.js";
@@ -118,8 +118,11 @@ const SmartAutoMoveNGIndicator = GObject.registerClass(
 //// EXTENSION CLASS
 export default class SmartAutoMoveNG extends Extension {
     enable() {
-        this._prevCheckWorkspaces = Main.wm._workspaceTracker._checkWorkspaces;
-        Main.wm._workspaceTracker._checkWorkspaces = this._getCheckWorkspaceOverride(this._prevCheckWorkspaces);
+        this._injectionManager = new InjectionManager();
+        this._injectionManager.overrideMethod(Main.wm._workspaceTracker, "_checkWorkspaces", (originalMethod) =>
+            this._getCheckWorkspaceOverride(originalMethod)
+        );
+
         this._activeWindows = new Map();
         this._settings = this.getSettings();
         this._indicator = null; // Quick Settings indicator see _onParamChangedUI
@@ -168,7 +171,9 @@ export default class SmartAutoMoveNG extends Extension {
     }
 
     disable() {
-        Main.wm._workspaceTracker._checkWorkspaces = this._prevCheckWorkspaces;
+        this._injectionManager.clear();
+        this._injectionManager = null;
+
         this._debug("disable()");
         //remove timeout signals
         if (this._timeoutSyncSignal !== null) GLib.Source.remove(this._timeoutSyncSignal);

--- a/SmartAutoMoveNG@lauinger-clan.de/extension.js
+++ b/SmartAutoMoveNG@lauinger-clan.de/extension.js
@@ -12,17 +12,10 @@ import * as QuickSettings from "resource:///org/gnome/shell/ui/quickSettings.js"
 import * as Main from "resource:///org/gnome/shell/ui/main.js";
 import { PopupAnimation } from "resource:///org/gnome/shell/ui/boxpointer.js";
 import * as PopupMenu from "resource:///org/gnome/shell/ui/popupMenu.js";
-import { PACKAGE_VERSION } from "resource:///org/gnome/shell/misc/config.js";
 
 import * as Common from "./lib/common.js";
 
 const QuickSettingsMenu = Main.panel.statusArea.quickSettings;
-
-function isGnome49OrHigher() {
-    // GNOME Shell exports its version as a string, e.g. "49.0"
-    const majorVersion = Number.parseInt(PACKAGE_VERSION.split(".")[0], 10);
-    return majorVersion >= 49;
-}
 
 //quick settings
 const SmartAutoMoveNGMenuToggle = GObject.registerClass(
@@ -133,7 +126,6 @@ export default class SmartAutoMoveNG extends Extension {
         this._finalMenuIcon = this._getMenuIcon();
         this._overrides = {};
         this._savedWindows = {};
-        this._isGnome49OrHigher = isGnome49OrHigher();
         this._onParamChangedDebugLogging();
 
         this._debug("enable()");
@@ -201,7 +193,6 @@ export default class SmartAutoMoveNG extends Extension {
         this._activeWindows = null;
         this._indicator?.destroy();
         this._indicator = null;
-        this._isGnome49OrHigher = null;
     }
 
     _getCheckWorkspaceOverride(originalMethod) {
@@ -347,7 +338,7 @@ export default class SmartAutoMoveNG extends Extension {
             //user_time: win.get_user_time(),
             workspace: win.get_workspace().index(),
             // maximized: For GNOME 49+, only boolean is available. For older, bitmask.
-            maximized: this._isGnome49OrHigher ? win.is_maximized() : win.get_maximized(),
+            maximized: win.is_maximized(),
             fullscreen: win.is_fullscreen(),
             above: win.is_above(),
             monitor: win.get_monitor(),
@@ -732,11 +723,8 @@ export default class SmartAutoMoveNG extends Extension {
                 messagestate = _("disabled");
             }
             const finalmessage = `${this.metadata.name}\n${message} ${messagestate}`;
-            if (this._isGnome49OrHigher) {
-                Main.osdWindowManager.showAll(this._finalMenuIcon, finalmessage, null, null);
-            } else {
-                Main.osdWindowManager.show(-1, this._finalMenuIcon, finalmessage, null, null);
-            }
+
+            Main.osdWindowManager.showAll(this._finalMenuIcon, finalmessage, null, null);
         }
     }
 }

--- a/SmartAutoMoveNG@lauinger-clan.de/metadata.json
+++ b/SmartAutoMoveNG@lauinger-clan.de/metadata.json
@@ -3,7 +3,7 @@
     "gettext-domain": "SmartAutoMoveNG",
     "description": "Smart Auto Move NG learns the position, size, and workspace of your application windows and restores them on subsequent launches. Supports Wayland.\n\nDynamic workspaces are supported for GNOME 48 and later.\n\nFor more control, set the default behavior to IGNORE and then selectively RESTORE only desired apps.\n\nForked from https://github.com/khimaros/smart-auto-move",
     "uuid": "SmartAutoMoveNG@lauinger-clan.de",
-    "shell-version": ["48", "49", "50"],
+    "shell-version": ["50"],
     "original-author": "khimaros",
     "url": "https://github.com/ChrisLauinger77/gnome-shell-extension-SmartAutoMoveNG",
     "settings-schema": "org.gnome.shell.extensions.SmartAutoMoveNG",
@@ -13,5 +13,5 @@
         "paypal": "ChrisLauinger"
     },
     "version": 999,
-    "version-name": "50.10"
+    "version-name": "50.11"
 }


### PR DESCRIPTION
Replaces direct method override with InjectionManager for cleaner injection and code maintenance. 

Removes compatibility code for GNOME versions 48 and 49, simplifying the codebase by ensuring support for version 50+ only.

Relates to issues #68 and the duplicate #69