### PR TITLE
fix: Skip _ensureSavedWindow() for windows losing their workspace on unmanage

### DIFF
--- a/SmartAutoMoveNG@lauinger-clan.de/extension.js
+++ b/SmartAutoMoveNG@lauinger-clan.de/extension.js
@@ -859,6 +859,15 @@ export default class SmartAutoMoveNG extends Extension {
 
         if (this._activeRestores.has(win) || this._restoreSaveGuards.has(win)) return;
 
+        // a window that is being unmanaged has already lost its workspace: mutter's
+        // meta_window_unmanage() calls set_workspace_state(window, FALSE, NULL), which
+        // emits workspace-changed and notify::on-all-workspaces before the "unmanaged"
+        // handler gets to stop tracking it. there is nothing worth saving at that point,
+        // and _windowData() would throw on win.get_workspace().index().
+        // sticky windows are unaffected - get_workspace() returns the active workspace
+        // when on_all_workspaces is set.
+        if (win.get_workspace() === null) return;
+
         const wsh = this._windowSectionHash(win);
         if (wsh === null) return;
 


### PR DESCRIPTION
Closing any window logs two errors:

```
TypeError: can't access property "index", win.get_workspace() is null
```

On a 16 h GNOME 50 session that was 472 entries in the journal from normal desktop use.

### Cause

mutter's `meta_window_unmanage()` calls `set_workspace_state(window, FALSE, NULL)`, which nulls the workspace and emits both `workspace-changed` and `notify::on-all-workspaces`. Both are connected to `_ensureSavedWindow()`, which reaches `_windowData()` → `win.get_workspace().index()` on a window that is already being destroyed. The extension's own `unmanaged` handler, which would stop tracking the window, only runs afterwards — so every close hits the unguarded call twice.

### Fix

One more early return among the guards already at the top of `_ensureSavedWindow()`. A window without a workspace is on its way out, so there is nothing worth saving.

Sticky windows are not affected: `meta_window_get_workspace()` returns the active workspace when `on_all_workspaces` is set, so the null check can only skip windows that are going away.

### Verification

Reproduced rather than reasoned about, in a nested headless shell (`dbus-run-session -- gnome-shell --headless`) with a GTK window that outlives the startup delay and is then closed:

- unpatched: the exact error pair per close
- patched: zero errors, and the window is still saved and restored correctly

Also running on a normal GNOME 50 desktop session: 478 occurrences on the last unpatched boot, 0 since.

`npm run lint` is clean.