### PR TITLE
Ensures preferences dialog cleanup and lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ inside the directory with that exact name.
   `prefs.js`.
 - `SmartAutoMoveNG@lauinger-clan.de/metadata.json`: extension metadata,
   supported shell versions, release version, gettext domain, and schema id.
-- `SmartAutoMoveNG@lauinger-clan.de/test/common.test.js`: lightweight assertion
+- `test/common.test.js`: lightweight assertion
   coverage for the pure helpers in `lib/common.js`.
 - `po/`: gettext template and translations.
 - `examples/`: example dconf configurations.
@@ -102,7 +102,7 @@ Before finishing changes, run the validations that match the edit:
 
 - JavaScript changes: `npm run lint`.
 - Shared matching logic: run or extend
-  `SmartAutoMoveNG@lauinger-clan.de/test/common.test.js` with the available GJS
+  `test/common.test.js` with the available GJS
   setup, or explain if local GJS execution is not available.
 - Schema, metadata, packaging, icon, UI, or translation changes:
   `./smartautomoveng.sh zip`.

--- a/SmartAutoMoveNG@lauinger-clan.de/metadata.json
+++ b/SmartAutoMoveNG@lauinger-clan.de/metadata.json
@@ -3,7 +3,9 @@
     "gettext-domain": "SmartAutoMoveNG",
     "description": "Smart Auto Move NG learns the position, size, and workspace of your application windows and restores them on subsequent launches. Supports Wayland.\n\nDynamic workspaces are supported for GNOME 48 and later.\n\nFor more control, set the default behavior to IGNORE and then selectively RESTORE only desired apps.\n\nForked from https://github.com/khimaros/smart-auto-move",
     "uuid": "SmartAutoMoveNG@lauinger-clan.de",
-    "shell-version": ["50"],
+    "shell-version": [
+        "50"
+    ],
     "original-author": "khimaros",
     "url": "https://github.com/ChrisLauinger77/gnome-shell-extension-SmartAutoMoveNG",
     "settings-schema": "org.gnome.shell.extensions.SmartAutoMoveNG",
@@ -13,5 +15,5 @@
         "paypal": "ChrisLauinger"
     },
     "version": 999,
-    "version-name": "50.15"
+    "version-name": "50.16"
 }

--- a/SmartAutoMoveNG@lauinger-clan.de/prefs.js
+++ b/SmartAutoMoveNG@lauinger-clan.de/prefs.js
@@ -72,11 +72,23 @@ const AppChooser = GObject.registerClass(
 
         showChooser() {
             return new Promise((resolve) => {
-                const signalId = this.selectBtn.connect("clicked", () => {
-                    this.close();
-                    this.selectBtn.disconnect(signalId);
-                    const row = this.listBox.get_selected_row();
+                const signalIds = {
+                    select: null,
+                    close: null,
+                };
+                const finish = (row) => {
+                    this.selectBtn.disconnect(signalIds.select);
+                    this.disconnect(signalIds.close);
                     resolve(row);
+                };
+                signalIds.select = this.selectBtn.connect("clicked", () => {
+                    const selectedRow = this.listBox.get_selected_row();
+                    finish(selectedRow);
+                    this.close();
+                });
+                signalIds.close = this.connect("close-request", () => {
+                    finish(null);
+                    return false;
                 });
                 this.present();
             });
@@ -254,13 +266,20 @@ export default class SAMPreferences extends ExtensionPreferences {
         startupdelayspin.set_climb_rate(100);
         startupdelayspin.set_numeric(true);
         this._rebuildOverrides = true; // do we need to rebuild the overrides list?
-        this._addResetButton(window, this.getSettings());
+        const settings = this.getSettings();
+        this._addResetButton(window, settings);
 
-        this._general(this.getSettings(), builder);
+        this._general(settings, builder);
         const savedwindowsRows = [];
-        this._savedwindows(this.getSettings(), builder, savedwindowsRows, page2);
+        const changedSavedWindowsSignal = this._savedwindows(settings, builder, savedwindowsRows, page2);
         const overridesRows = [];
-        this._overrides(this.getSettings(), builder, overridesRows, page3);
+        const [changedOverridesSignal, appChooser] = this._overrides(settings, builder, overridesRows, page3);
+        window.connect("close-request", () => {
+            settings.disconnect(changedSavedWindowsSignal);
+            settings.disconnect(changedOverridesSignal);
+            appChooser.destroy();
+            return false;
+        });
     }
 
     _general(settings, builder) {
@@ -351,7 +370,7 @@ export default class SAMPreferences extends ExtensionPreferences {
             this._cleanupStaleSavedWindows(settings);
         });
         this._loadSavedWindowsSetting(settings, saved_windows_list_widget, saved_windows_list_objects, list_rows, page);
-        this.changedSavedWindowsSignal = settings.connect("changed::" + Common.SETTINGS_KEY_SAVED_WINDOWS, () => {
+        return settings.connect("changed::" + Common.SETTINGS_KEY_SAVED_WINDOWS, () => {
             this._loadSavedWindowsSetting(
                 settings,
                 saved_windows_list_widget,
@@ -409,9 +428,10 @@ export default class SAMPreferences extends ExtensionPreferences {
             }
         });
         this._loadOverridesSetting(settings, overrides_list_widget, overrides_list_objects, list_rows);
-        this.changedOverridesSignal = settings.connect("changed::" + Common.SETTINGS_KEY_OVERRIDES, () => {
+        const changedOverridesSignal = settings.connect("changed::" + Common.SETTINGS_KEY_OVERRIDES, () => {
             this._loadOverridesSetting(settings, overrides_list_widget, overrides_list_objects, list_rows);
         });
+        return [changedOverridesSignal, myAppChooser];
     }
 
     _clearListWidget(list_widget, list_objects, list_rows) {
@@ -538,7 +558,6 @@ export default class SAMPreferences extends ExtensionPreferences {
                 title: _("Edit Saved Window"),
                 modal: true,
                 transient_for: page.get_root(),
-                hide_on_close: true,
                 width_request: 400,
                 height_request: 600,
                 resizable: false,

--- a/test/common.test.js
+++ b/test/common.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import * as Common from "../lib/common.js";
+import * as Common from "../SmartAutoMoveNG@lauinger-clan.de/lib/common.js";
 
 function assertScore(sw, query, want_score) {
     const score = Common.scoreWindow(sw, query);


### PR DESCRIPTION
Addresses potential memory leaks and ensures proper resource release within the extension's preferences windows.

Key improvements include:
- Robust signal disconnection for the application chooser dialog (`AppChooser`), handling both explicit selection and general dialog closure.
- Centralized management of `GSettings` change signals and explicit child dialog destruction when the main preferences window closes.
- Refactored preference setup methods (`_savedwindows`, `_overrides`) to return signal IDs and dialog instances, enabling precise lifecycle management in the main preferences constructor.
- Removes a potentially conflicting `hide_on_close` property from the `EditSavedWindowDialog`.

This enhances the stability and resource efficiency of the preferences UI.

### Breaking Changes
None. This change is an internal fix.

### Review Focus
- Verification of the new signal connection and disconnection logic, particularly the `close-request` handlers for both the `AppChooser` and the main `SAMPreferences` window.
- Ensure all resources are properly released when the preferences window closes under various scenarios.