### PR TITLE
Updates extension for GNOME Shell 51 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Forked from https://github.com/khimaros/smart-auto-move
 
 <div align="center">
 
-![Gnome Extensions Downloads](https://img.shields.io/gnome-extensions/dt/SmartAutoMoveNG@lauinger-clan.de) ![GNOME Shell](https://img.shields.io/badge/GNOME-45%20--%2050-blue?logo=gnome&logoColor=white) ![GitHub License](https://img.shields.io/github/license/ChrisLauinger77/gnome-shell-extension-SmartAutoMoveNg)
+![Gnome Extensions Downloads](https://img.shields.io/gnome-extensions/dt/SmartAutoMoveNG@lauinger-clan.de) ![GNOME Shell](https://img.shields.io/badge/GNOME-45%20--%2051-blue?logo=gnome&logoColor=white) ![GitHub License](https://img.shields.io/github/license/ChrisLauinger77/gnome-shell-extension-SmartAutoMoveNg)
 
 </div>
 

--- a/SmartAutoMoveNG@lauinger-clan.de/extension.js
+++ b/SmartAutoMoveNG@lauinger-clan.de/extension.js
@@ -145,6 +145,7 @@ export default class SmartAutoMoveNG extends Extension {
         this._finalMenuIcon = this._getMenuIcon();
         this._overrides = {};
         this._savedWindows = {};
+        this._invalidJsonSettings = new Set();
         this._onParamChangedDebugLogging();
 
         this._debug("enable()");
@@ -540,6 +541,7 @@ export default class SmartAutoMoveNG extends Extension {
         this._ignoreWorkspace = null;
         this._overrides = null;
         this._savedWindows = null;
+        this._invalidJsonSettings = null;
     }
 
     _restoreSettings() {
@@ -561,15 +563,20 @@ export default class SmartAutoMoveNG extends Extension {
     }
 
     _saveSettings() {
-        const newOverrides = JSON.stringify(this._overrides);
-        this._settings.set_string(Common.SETTINGS_KEY_OVERRIDES, newOverrides);
+        if (!this._invalidJsonSettings.has(Common.SETTINGS_KEY_OVERRIDES)) {
+            const newOverrides = JSON.stringify(this._overrides);
+            this._settings.set_string(Common.SETTINGS_KEY_OVERRIDES, newOverrides);
+        }
 
-        const oldSavedWindows = this._settings.get_string(Common.SETTINGS_KEY_SAVED_WINDOWS);
-        const newSavedWindows = JSON.stringify(this._savedWindows);
-        if (oldSavedWindows === newSavedWindows) return;
-        this._debug("_saveSettings()");
-        this._dumpSavedWindows();
-        this._settings.set_string(Common.SETTINGS_KEY_SAVED_WINDOWS, newSavedWindows);
+        if (!this._invalidJsonSettings.has(Common.SETTINGS_KEY_SAVED_WINDOWS)) {
+            const oldSavedWindows = this._settings.get_string(Common.SETTINGS_KEY_SAVED_WINDOWS);
+            const newSavedWindows = JSON.stringify(this._savedWindows);
+            if (oldSavedWindows !== newSavedWindows) {
+                this._debug("_saveSettings()");
+                this._dumpSavedWindows();
+                this._settings.set_string(Common.SETTINGS_KEY_SAVED_WINDOWS, newSavedWindows);
+            }
+        }
     }
 
     _addTimeout(priority, interval, callback) {
@@ -1284,7 +1291,7 @@ export default class SmartAutoMoveNG extends Extension {
     }
 
     _onParamChangedOverrides() {
-        this._overrides = JSON.parse(this._settings.get_string(Common.SETTINGS_KEY_OVERRIDES));
+        this._overrides = this._readJsonSetting(Common.SETTINGS_KEY_OVERRIDES);
         this._updateStats();
         if (this._quickSettings) {
             this._indicator.menuToggle.setMenuTitleAndHeader(this._savedWindowsCount, this._overridesCount);
@@ -1294,7 +1301,7 @@ export default class SmartAutoMoveNG extends Extension {
 
     _onParamChangedSavedWindows() {
         const canceledRestores = this._cancelActiveRestores();
-        this._savedWindows = JSON.parse(this._settings.get_string(Common.SETTINGS_KEY_SAVED_WINDOWS));
+        this._savedWindows = this._readJsonSetting(Common.SETTINGS_KEY_SAVED_WINDOWS);
         this._updateStats();
         if (this._quickSettings) {
             this._indicator.menuToggle.setMenuTitleAndHeader(this._savedWindowsCount, this._overridesCount);
@@ -1313,6 +1320,20 @@ export default class SmartAutoMoveNG extends Extension {
         this._ignoreMonitor = this._settings.get_boolean(Common.SETTINGS_KEY_IGNORE_MONITOR);
         this._debug("_onParamChangedIgnoreMonitor(): " + this._ignoreMonitor);
         this._sendOSDNotification(_("Ignore Monitor"), this._ignoreMonitor);
+    }
+
+    _readJsonSetting(key) {
+        let parseFailed = false;
+        const value = Common.parseJsonObject(this._settings.get_string(key), (error) => {
+            parseFailed = true;
+            this.getLogger().error(`Invalid JSON in ${key}; using an empty object: ${error.message}`);
+        });
+        if (parseFailed) {
+            this._invalidJsonSettings.add(key);
+        } else {
+            this._invalidJsonSettings.delete(key);
+        }
+        return value;
     }
 
     _sendOSDNotification(message, state) {

--- a/SmartAutoMoveNG@lauinger-clan.de/extension.js
+++ b/SmartAutoMoveNG@lauinger-clan.de/extension.js
@@ -11,7 +11,6 @@ import St from "gi://St";
 import { Extension, InjectionManager, gettext as _ } from "resource:///org/gnome/shell/extensions/extension.js";
 import * as QuickSettings from "resource:///org/gnome/shell/ui/quickSettings.js";
 import * as Main from "resource:///org/gnome/shell/ui/main.js";
-import { PopupAnimation } from "resource:///org/gnome/shell/ui/boxpointer.js";
 import * as PopupMenu from "resource:///org/gnome/shell/ui/popupMenu.js";
 
 import * as Common from "./lib/common.js";
@@ -54,7 +53,7 @@ const SmartAutoMoveNGMenuToggle = GObject.registerClass(
                 this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
                 const settingsItem = this.menu.addAction(_("Settings"), () => {
                     extension.openPreferences();
-                    QuickSettingsMenu.menu.close(PopupAnimation.FADE);
+                    QuickSettingsMenu.menu.close({ fadeOnly: true });
                 });
 
                 settingsItem.visible = Main.sessionMode.allowSettings;

--- a/SmartAutoMoveNG@lauinger-clan.de/lib/common.js
+++ b/SmartAutoMoveNG@lauinger-clan.de/lib/common.js
@@ -32,6 +32,19 @@ export const STALE_SAVED_WINDOW_MS = STALE_SAVED_WINDOW_DAYS * 24 * 60 * 60 * 10
 export const STALE_SAVED_WINDOW_DAYS_MIN = 1;
 export const STALE_SAVED_WINDOW_DAYS_MAX = 365;
 
+export function parseJsonObject(value, onError = null) {
+    try {
+        const parsed = JSON.parse(value);
+        if (parsed === null || Array.isArray(parsed) || typeof parsed !== "object") {
+            throw new TypeError("Expected a JSON object");
+        }
+        return parsed;
+    } catch (error) {
+        onError?.(error);
+        return {};
+    }
+}
+
 function levensteinDistance(a, b) {
     const m = [],
         min = Math.min;
@@ -149,7 +162,12 @@ export function matchingSavedWindow(saved_windows, wsh) {
 }
 
 export function cleanupNonOccupiedWindows(settings) {
-    const saved_windows = JSON.parse(settings.get_string(SETTINGS_KEY_SAVED_WINDOWS));
+    let parseFailed = false;
+    const saved_windows = parseJsonObject(settings.get_string(SETTINGS_KEY_SAVED_WINDOWS), () => {
+        parseFailed = true;
+    });
+    if (parseFailed) return;
+
     for (const wsh of Object.keys(saved_windows)) {
         const sws = saved_windows[wsh];
         saved_windows[wsh] = sws.filter((sw) => sw.occupied);
@@ -167,7 +185,11 @@ export function cleanupStaleSavedWindows(settings, maxAgeDays = settings.get_int
     maxAgeDays = Math.min(Math.max(maxAgeDays, STALE_SAVED_WINDOW_DAYS_MIN), STALE_SAVED_WINDOW_DAYS_MAX);
 
     const cutoff = now - maxAgeDays * 24 * 60 * 60 * 1000;
-    const saved_windows = JSON.parse(settings.get_string(SETTINGS_KEY_SAVED_WINDOWS));
+    let parseFailed = false;
+    const saved_windows = parseJsonObject(settings.get_string(SETTINGS_KEY_SAVED_WINDOWS), () => {
+        parseFailed = true;
+    });
+    if (parseFailed) return;
 
     for (const wsh of Object.keys(saved_windows)) {
         const sws = saved_windows[wsh];

--- a/SmartAutoMoveNG@lauinger-clan.de/metadata.json
+++ b/SmartAutoMoveNG@lauinger-clan.de/metadata.json
@@ -4,7 +4,7 @@
     "description": "Smart Auto Move NG learns the position, size, and workspace of your application windows and restores them on subsequent launches. Supports Wayland.\n\nDynamic workspaces are supported for GNOME 48 and later.\n\nFor more control, set the default behavior to IGNORE and then selectively RESTORE only desired apps.\n\nForked from https://github.com/khimaros/smart-auto-move",
     "uuid": "SmartAutoMoveNG@lauinger-clan.de",
     "shell-version": [
-        "50"
+        "50", "51"
     ],
     "original-author": "khimaros",
     "url": "https://github.com/ChrisLauinger77/gnome-shell-extension-SmartAutoMoveNG",
@@ -15,5 +15,5 @@
         "paypal": "ChrisLauinger"
     },
     "version": 999,
-    "version-name": "50.16"
+    "version-name": "51.0"
 }

--- a/SmartAutoMoveNG@lauinger-clan.de/metadata.json
+++ b/SmartAutoMoveNG@lauinger-clan.de/metadata.json
@@ -3,9 +3,7 @@
     "gettext-domain": "SmartAutoMoveNG",
     "description": "Smart Auto Move NG learns the position, size, and workspace of your application windows and restores them on subsequent launches. Supports Wayland.\n\nDynamic workspaces are supported for GNOME 48 and later.\n\nFor more control, set the default behavior to IGNORE and then selectively RESTORE only desired apps.\n\nForked from https://github.com/khimaros/smart-auto-move",
     "uuid": "SmartAutoMoveNG@lauinger-clan.de",
-    "shell-version": [
-        "50", "51"
-    ],
+    "shell-version": ["51"],
     "original-author": "khimaros",
     "url": "https://github.com/ChrisLauinger77/gnome-shell-extension-SmartAutoMoveNG",
     "settings-schema": "org.gnome.shell.extensions.SmartAutoMoveNG",

--- a/SmartAutoMoveNG@lauinger-clan.de/prefs.js
+++ b/SmartAutoMoveNG@lauinger-clan.de/prefs.js
@@ -267,22 +267,27 @@ export default class SAMPreferences extends ExtensionPreferences {
         startupdelayspin.set_numeric(true);
         this._rebuildOverrides = true; // do we need to rebuild the overrides list?
         const settings = this.getSettings();
+        const settingsSignalIds = [];
+        const timeoutIds = new Set();
         this._addResetButton(window, settings);
 
-        this._general(settings, builder);
+        this._general(settings, builder, settingsSignalIds);
         const savedwindowsRows = [];
-        const changedSavedWindowsSignal = this._savedwindows(settings, builder, savedwindowsRows, page2);
+        const changedSavedWindowsSignal = this._savedwindows(settings, builder, savedwindowsRows, page2, timeoutIds);
         const overridesRows = [];
         const [changedOverridesSignal, appChooser] = this._overrides(settings, builder, overridesRows, page3);
         window.connect("close-request", () => {
             settings.disconnect(changedSavedWindowsSignal);
             settings.disconnect(changedOverridesSignal);
+            for (const signalId of settingsSignalIds) settings.disconnect(signalId);
+            for (const timeoutId of timeoutIds) GLib.Source.remove(timeoutId);
+            timeoutIds.clear();
             appChooser.destroy();
             return false;
         });
     }
 
-    _general(settings, builder) {
+    _general(settings, builder, settingsSignalIds) {
         const generalBindings = [
             [Common.SETTINGS_KEY_DEBUG_LOGGING, "debug-logging-switch", "active"],
             [Common.SETTINGS_KEY_QUICKSETTINGS, "quicksettings-switch", "active"],
@@ -308,16 +313,18 @@ export default class SAMPreferences extends ExtensionPreferences {
                     settings.set_enum(key, widget[property]);
                 });
 
-                settings.connect(`changed::${key}`, () => {
-                    widget[property] = settings.get_enum(key);
-                });
+                settingsSignalIds.push(
+                    settings.connect(`changed::${key}`, () => {
+                        widget[property] = settings.get_enum(key);
+                    })
+                );
             } else {
                 settings.bind(key, widget, property, Gio.SettingsBindFlags.DEFAULT);
             }
         }
     }
 
-    _saveSettings(settings, builder, adwrowSaveButton) {
+    _saveSettings(settings, builder, adwrowSaveButton, timeoutIds) {
         const saved_windows_editor_workspace_widget = builder.get_object("saved-windows-editor-workspace-spin");
         settings.set_int(Common.SETTINGS_KEY_MAX_WORKSPACE, saved_windows_editor_workspace_widget.get_value());
         const saved_windows_editor_monitor_widget = builder.get_object("saved-windows-editor-monitor-spin");
@@ -335,14 +342,16 @@ export default class SAMPreferences extends ExtensionPreferences {
         adwrowSaveButton.set_title(_("Preferences Saved"));
 
         // Reset status after a delay
-        GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 3, () => {
+        const timeoutId = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 3, () => {
+            timeoutIds.delete(timeoutId);
             adwrowSaveButton.set_title(_("Save Preferences"));
             adwrowSaveButton.set_sensitive(true);
             return GLib.SOURCE_REMOVE;
         });
+        timeoutIds.add(timeoutId);
     }
 
-    _savedwindows(settings, builder, list_rows, page) {
+    _savedwindows(settings, builder, list_rows, page, timeoutIds) {
         const saved_windows_editor_workspace_widget = builder.get_object("saved-windows-editor-workspace-spin");
         saved_windows_editor_workspace_widget.set_value(settings.get_int(Common.SETTINGS_KEY_MAX_WORKSPACE));
         const saved_windows_editor_monitor_widget = builder.get_object("saved-windows-editor-monitor-spin");
@@ -357,7 +366,7 @@ export default class SAMPreferences extends ExtensionPreferences {
         saved_windows_editor_height_widget.set_value(settings.get_int(Common.SETTINGS_KEY_MAX_HEIGHT));
         const saved_windows_editor_save_widget = builder.get_object("saved-windows-editor-save-button");
         saved_windows_editor_save_widget.connect("activated", () => {
-            this._saveSettings(settings, builder, saved_windows_editor_save_widget);
+            this._saveSettings(settings, builder, saved_windows_editor_save_widget, timeoutIds);
         });
         const saved_windows_list_widget = builder.get_object("saved-windows-listbox");
         const saved_windows_list_objects = [];
@@ -383,7 +392,12 @@ export default class SAMPreferences extends ExtensionPreferences {
 
     _override(settings, wsh, swtitle) {
         const o = { query: { title: swtitle }, action: 0 };
-        const overrides = JSON.parse(settings.get_string(Common.SETTINGS_KEY_OVERRIDES));
+        let parseFailed = false;
+        const overrides = this._readJsonSetting(settings, Common.SETTINGS_KEY_OVERRIDES, () => {
+            parseFailed = true;
+        });
+        if (parseFailed) return;
+
         if (!Object.hasOwn(overrides, wsh)) overrides[wsh] = [];
         overrides[wsh].unshift(o);
         settings.set_string(Common.SETTINGS_KEY_OVERRIDES, JSON.stringify(overrides));
@@ -394,7 +408,12 @@ export default class SAMPreferences extends ExtensionPreferences {
             action: 0,
             threshold: settings.get_double(Common.SETTINGS_KEY_MATCH_THRESHOLD),
         };
-        const overrides = JSON.parse(settings.get_string(Common.SETTINGS_KEY_OVERRIDES));
+        let parseFailed = false;
+        const overrides = this._readJsonSetting(settings, Common.SETTINGS_KEY_OVERRIDES, () => {
+            parseFailed = true;
+        });
+        if (parseFailed) return;
+
         if (!Object.hasOwn(overrides, wsh)) overrides[wsh] = [];
         overrides[wsh].push(o);
         settings.set_string(Common.SETTINGS_KEY_OVERRIDES, JSON.stringify(overrides));
@@ -453,7 +472,7 @@ export default class SAMPreferences extends ExtensionPreferences {
             this._rebuildOverrides = true;
             return;
         }
-        const overrides = JSON.parse(settings.get_string(Common.SETTINGS_KEY_OVERRIDES));
+        const overrides = this._readJsonSetting(settings, Common.SETTINGS_KEY_OVERRIDES);
         this._clearListWidget(list_widget, list_objects, list_rows);
         for (const wsh of Object.keys(overrides)) {
             const adwexprow = new Adw.ExpanderRow();
@@ -543,7 +562,7 @@ export default class SAMPreferences extends ExtensionPreferences {
     }
 
     _edit_window(settings, wsh, page) {
-        const saved_windows = JSON.parse(settings.get_string(Common.SETTINGS_KEY_SAVED_WINDOWS));
+        const saved_windows = this._readJsonSetting(settings, Common.SETTINGS_KEY_SAVED_WINDOWS);
         const sws = saved_windows[wsh];
         const sw = sws.find((window) => !window.occupied);
         if (!sw) return;
@@ -628,7 +647,7 @@ export default class SAMPreferences extends ExtensionPreferences {
     }
 
     _loadSavedWindowsSetting(settings, list_widget, list_objects, list_rows, page) {
-        const saved_windows = JSON.parse(settings.get_string(Common.SETTINGS_KEY_SAVED_WINDOWS));
+        const saved_windows = this._readJsonSetting(settings, Common.SETTINGS_KEY_SAVED_WINDOWS);
         this._clearListWidget(list_widget, list_objects, list_rows);
         for (const wsh of Object.keys(saved_windows)) {
             const sws = saved_windows[wsh];
@@ -676,6 +695,13 @@ export default class SAMPreferences extends ExtensionPreferences {
         } else if (settings.is_writable(strKey)) {
             settings.reset(strKey);
         }
+    }
+
+    _readJsonSetting(settings, key, onError = null) {
+        return Common.parseJsonObject(settings.get_string(key), (error) => {
+            this.getLogger().error(`Invalid JSON in ${key}; using an empty object: ${error.message}`);
+            onError?.(error);
+        });
     }
 
     _findWidgetByType(parent, type) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gnome-shell-extension-smart-auto-move-ng",
-    "version": "1.0.0",
+    "version": "51.0.0",
     "description": "Smart Auto Move learns the position, size, and workspace of your application windows and restores them on subsequent launches. Supports Wayland.",
     "main": "SmartAutoMoveNG@lauinger-clan.de/extension.js",
     "scripts": {

--- a/test/common.test.js
+++ b/test/common.test.js
@@ -2,6 +2,19 @@
 
 import * as Common from "../SmartAutoMoveNG@lauinger-clan.de/lib/common.js";
 
+console.assert(JSON.stringify(Common.parseJsonObject('{"window": []}')) === '{"window":[]}');
+
+let parseError = null;
+console.assert(
+    JSON.stringify(
+        Common.parseJsonObject("not JSON", (error) => {
+            parseError = error;
+        })
+    ) === "{}"
+);
+console.assert(parseError instanceof SyntaxError);
+console.assert(JSON.stringify(Common.parseJsonObject("[]")) === "{}");
+
 function assertScore(sw, query, want_score) {
     const score = Common.scoreWindow(sw, query);
     console.assert(want_score === score, {
@@ -232,6 +245,24 @@ function createStringSetting(initialValue) {
             value = newValue;
         },
     };
+}
+
+{
+    const malformedValue = '{"window":';
+    const settings = createStringSetting(malformedValue);
+
+    Common.cleanupNonOccupiedWindows(settings);
+
+    console.assert(settings.get_string() === malformedValue, settings.get_string());
+}
+
+{
+    const malformedValue = '{"window":';
+    const settings = createStringSetting(malformedValue);
+
+    Common.cleanupStaleSavedWindows(settings);
+
+    console.assert(settings.get_string() === malformedValue, settings.get_string());
 }
 
 {


### PR DESCRIPTION
## Summary

- add GNOME Shell 51 compatibility and update the extension version metadata
- safely parse persisted `saved-windows` and `overrides` JSON, logging invalid data and falling back to an empty object
- disconnect preferences settings handlers when the window closes
- track and remove pending preferences timeouts during window cleanup
- add tests for valid, malformed, and non-object JSON settings values

## Review focus

- verify the `shell-version` and `version-name` updates in `metadata.json`
- verify invalid persisted JSON no longer prevents the extension or preferences from loading
- verify reopening and closing preferences does not retain settings handlers or timeout sources

## Validation

- `npm run lint`
- `gjs -m test/common.test.js`
- `git diff --check`
- `./smartautomoveng.sh zip`
- extension ZIP integrity check with `unzip -t`

## Breaking changes

None. Existing valid settings remain compatible and no migration is required.