### PR TITLE
Add install-dependencies helper command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ inside the directory with that exact name.
 
 ## Useful Commands
 
-- `npm install`: install local JavaScript tooling.
+- `./smartautomoveng.sh install-dependencies`: install the locked JavaScript dependencies.
 - `npm run lint`: run ESLint across the repository.
 - `./smartautomoveng.sh zip`: build
   `SmartAutoMoveNG@lauinger-clan.de.shell-extension.zip`.
@@ -49,6 +49,9 @@ inside the directory with that exact name.
   extension locally.
 - `./smartautomoveng.sh translate`: update `po/SmartAutoMoveNG.pot` and merge
   existing `.po` files after user-visible string changes.
+
+Run `./smartautomoveng.sh install-dependencies` after pulling or rebasing remote
+changes that modify `package-lock.json`, particularly Renovate updates.
 
 Notes:
 

--- a/smartautomoveng.sh
+++ b/smartautomoveng.sh
@@ -13,6 +13,9 @@ source "$script_dir/.githooks/version-actions.sh"
 echo "Running $0 for $extension with arguments: $@"
 
 case "${1:-}" in
+  install-dependencies)
+    npm ci
+    ;;
   cleanup)
     if [[ -f "$extensionfile" ]]; then
       rm -- "$extensionfile"
@@ -68,7 +71,7 @@ case "${1:-}" in
     echo "Done."
     ;;
   *)
-    echo "Usage: $0 {zip|pack|install|translate|upload|cleanup|check-version|update-version|setup-hooks}"
+    echo "Usage: $0 {install-dependencies|zip|pack|install|translate|upload|cleanup|check-version|update-version|setup-hooks}"
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary

- add an `install-dependencies` command to the repository helper that runs `npm ci` from the repository root
- include the command in the helper usage output
- document running the command after lockfile changes, particularly Renovate updates

## Validation

- helper shell syntax check
- `install-dependencies` command
- `npm run lint`
- helper usage output
- generated artifact scan
